### PR TITLE
feat(chat): TanStack AIチャットUIとテーマ切替ツールを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@modelcontextprotocol/sdk": "^1.23.0",
     "@openai/agents": "^0.3.3",
     "@openai/agents-core": "^0.3.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/ai": "^0.2.2",
     "@tanstack/ai-ollama": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@openai/agents-core':
         specifier: ^0.3.3
         version: 0.3.3(ws@8.18.3)(zod@4.1.13)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tailwindcss/vite':
         specifier: ^4.0.6
         version: 4.1.17(vite@7.2.4(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6))

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -7,6 +7,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@/components/ui/sidebar'
+import { OpenChat } from '@/features/chat/components/open-chat'
 
 export function Layout(props: { children?: React.ReactNode }) {
   const { children } = props
@@ -25,6 +26,7 @@ export function Layout(props: { children?: React.ReactNode }) {
         <SiteHeader />
         <div className="w-full h-full overflow-auto">{children}</div>
       </SidebarInset>
+      <OpenChat />
     </SidebarProvider>
   )
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { useChat } from '@tanstack/ai-react'
+import ReactMarkdown from 'react-markdown'
+
+import { fetchIpcEvents } from '@/lib/fetchIpcEvents'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export function Chat() {
+  const [input, setInput] = useState('')
+  const { messages, sendMessage, isLoading } = useChat({
+    connection: fetchIpcEvents(),
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (input.trim() && !isLoading) {
+      sendMessage(input)
+      setInput('')
+    }
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className="p-2 mb-2 border rounded-lg bg-background"
+          >
+            <div className="font-bold mb-1">{msg.role}</div>
+            {msg.parts.map((part, idx) => {
+              // thinking part
+              if (part.type === 'thinking') {
+                return (
+                  <details
+                    key={idx}
+                    open={false}
+                    className="text-sm text-accent-foreground italic bg-accent p-2 rounded-md mb-2"
+                  >
+                    <summary>Thinking...</summary>
+                    {part.content}
+                  </details>
+                )
+              }
+
+              // tool-call part
+              if (part.type === 'tool-call') {
+                return (
+                  <details
+                    key={idx}
+                    open={false}
+                    className="text-sm text-accent-foreground italic bg-accent p-2 rounded-md mb-2"
+                  >
+                    <summary>Tool Call: {part.name}</summary>
+                    <pre className="not-italic">
+                      {JSON.stringify(part, null, 2)}
+                    </pre>
+                  </details>
+                )
+              }
+
+              // text part
+              if (part.type === 'text') {
+                return (
+                  <div key={idx} className="">
+                    <ReactMarkdown>{part.content}</ReactMarkdown>
+                  </div>
+                )
+              }
+
+              // ...other part types
+              return null
+            })}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="flex gap-2 p-2 pt-0">
+        <Input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          disabled={isLoading}
+        ></Input>
+        <Button variant="secondary" type="submit" disabled={isLoading}>
+          Send
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/src/features/chat/components/open-chat.tsx
+++ b/src/features/chat/components/open-chat.tsx
@@ -1,0 +1,43 @@
+import { BotIcon, MessageCircleCodeIcon } from 'lucide-react'
+
+import { Chat } from './chat'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+
+export function OpenChat() {
+  return (
+    <Dialog modal={false}>
+      <DialogTrigger asChild>
+        <Button
+          className="fixed top-2 right-4 z-50 shadow"
+          variant="outline"
+          size="icon-sm"
+        >
+          <MessageCircleCodeIcon />
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        className="top-2 left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md"
+        // ダイアログ外クリックで閉じないようにする
+        onInteractOutside={(e) => e.preventDefault()}
+        // ダイアログ外クリックで閉じないようにする
+        onPointerDownOutside={(e) => e.preventDefault()}
+        // ESC キーで閉じないようにする
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <h2 className="flex items-center text-lg font-semibold">
+            <BotIcon className="inline mb-1 mr-2" />
+            Chat
+          </h2>
+        </DialogHeader>
+        <Chat />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/routes/demo.chat-t.tsx
+++ b/src/routes/demo.chat-t.tsx
@@ -1,82 +1,15 @@
-import { useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { useChat } from '@tanstack/ai-react'
-import ReactMarkdown from 'react-markdown'
-
-import { fetchIpcEvents } from '@/lib/fetchIpcEvents'
+import { Chat } from '@/features/chat/components/chat'
 
 export const Route = createFileRoute('/demo/chat-t')({
   component: RouteComponent,
+  loader: () => ({ crumb: 'AIチャット(TanStack AI)' }),
 })
 
 function RouteComponent() {
-  const [input, setInput] = useState('')
-  const { messages, sendMessage, isLoading } = useChat({
-    connection: fetchIpcEvents(),
-  })
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    if (input.trim() && !isLoading) {
-      sendMessage(input)
-      setInput('')
-    }
-  }
-
   return (
     <div>
-      <div className="p-2">
-        {messages.map((msg) => (
-          <div
-            key={msg.id}
-            className="p-2 mb-2 border rounded-lg bg-background"
-          >
-            <div className="font-bold mb-1">{msg.role}</div>
-            {msg.parts.map((part, idx) => {
-              // thinking part
-              if (part.type === 'thinking') {
-                return (
-                  <details
-                    key={idx}
-                    open={false}
-                    className="text-sm text-accent-foreground italic bg-accent p-2 rounded-md mb-2"
-                  >
-                    <summary>Thinking...</summary>
-                    {part.content}
-                  </details>
-                )
-              }
-
-              // text part
-              if (part.type === 'text') {
-                return (
-                  <div key={idx} className="">
-                    <ReactMarkdown>{part.content}</ReactMarkdown>
-                  </div>
-                )
-              }
-
-              // ...other part types
-              return null
-            })}
-          </div>
-        ))}
-      </div>
-      <form onSubmit={handleSubmit}>
-        <input
-          className="border px-2 py-1 mr-2"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          disabled={isLoading}
-        ></input>
-        <button
-          className="border px-2 py-1 bg-blue-500 text-white disabled:bg-gray-400"
-          type="submit"
-          disabled={isLoading}
-        >
-          Send
-        </button>
-      </form>
+      <Chat />
     </div>
   )
 }


### PR DESCRIPTION
## 概要
- TanStack AI を使ったチャットUIを共通コンポーネント化し、レイアウト常駐のチャット起動ボタンを追加しました。
- Electron main 側で「テーマを dark/light に切り替える」tool を定義し、チャットから呼び出せるようにしました。

## 変更内容
- Electron(main): [@tanstack/ai](https://www.npmjs.com/package/@tanstack/ai) の tools に `switch_theme_dark` / `switch_theme_light` を追加し、`nativeTheme.themeSource` を切り替え可能に
- Electron(main): tool call 等で `message.content === null` のケースを許容（ログ警告で落ちないように）
- UI: チャット表示を `src/features/chat/components/chat.tsx` に切り出し（thinking / tool-call / text の表示対応）
- UI: Radix Dialog ベースの `Dialog` を追加し、右上固定のチャット起動ボタン `OpenChat` をレイアウトに常駐
- Route: `/demo/chat-t` は共通 `Chat` を利用する形に整理（crumb も追加）

## 影響範囲
- 依存追加: `@radix-ui/react-dialog`（UIダイアログ）
- 画面: レイアウト配下の全画面にチャット起動ボタンが表示されます（`Layout` に `OpenChat` を追加したため）
- テーマ: AI tool 呼び出しによりアプリ全体のテーマが `nativeTheme.themeSource` 経由で切り替わります（グローバル影響）

## 動作確認
- [x] `pnpm test`
- [x] `pnpm dev`
- [x] `pnpm build` → exe 起動

## レビュー観点
- `nativeTheme.themeSource` の変更が想定UI/UXに合うか（常時切替可能で良いか、永続化が必要か等）
- tool の公開範囲が意図通りか（チャット経由でテーマ変更を許可することの妥当性）
- `Dialog modal={false}` + 外クリック/ESC無効化の挙動が期待通りか（閉じ方・アクセシビリティ）

## 関連リンク
- なし