### PR TITLE
feat(auth): オフライン認証（SQLite）とログイン導線を追加

### DIFF
--- a/electron/main/features/auth.ts
+++ b/electron/main/features/auth.ts
@@ -1,12 +1,7 @@
 import type { WebContents } from 'electron'
 
 import type { ApiInterface, WithWebContentsApi } from '../lib/ipc'
-import type { DataBase } from '../services/db/db'
-import {
-  getAuthStatus,
-  login as loginService,
-  logout as logoutService,
-} from '../services/auth/authService'
+import type { AuthRuntime } from '../services/auth/authRuntime'
 import type { AuthStatus } from '../services/auth/authService'
 
 // -----------------------------------------------------------------------------
@@ -16,8 +11,7 @@ export const AUTH_API_KEY = 'auth' as const
 export type AuthApiKey = typeof AUTH_API_KEY
 
 export type AuthContext = {
-  getDb: () => DataBase | null
-  setDb: (db: DataBase | null) => void
+  getRuntime: () => AuthRuntime
 }
 
 // -----------------------------------------------------------------------------
@@ -37,21 +31,15 @@ export function getAuthApi(
 ): WithWebContentsApi<AuthApi> {
   return {
     getStatus: async (webContents) => {
-      const db = getContext(webContents).getDb()
-      if (!db) throw new Error('Auth DB is not initialized')
-      return getAuthStatus(db)
+      return getContext(webContents).getRuntime().getStatus()
     },
 
     login: async (username, password, webContents) => {
-      const db = getContext(webContents).getDb()
-      if (!db) throw new Error('Auth DB is not initialized')
-      return loginService(db, username, password)
+      return getContext(webContents).getRuntime().login(username, password)
     },
 
     logout: async (webContents) => {
-      const db = getContext(webContents).getDb()
-      if (!db) throw new Error('Auth DB is not initialized')
-      logoutService(db)
+      getContext(webContents).getRuntime().logout()
     },
   }
 }

--- a/electron/main/features/auth.ts
+++ b/electron/main/features/auth.ts
@@ -1,0 +1,57 @@
+import type { WebContents } from 'electron'
+
+import type { ApiInterface, WithWebContentsApi } from '../lib/ipc'
+import type { DataBase } from '../services/db/db'
+import {
+  getAuthStatus,
+  login as loginService,
+  logout as logoutService,
+} from '../services/auth/authService'
+import type { AuthStatus } from '../services/auth/authService'
+
+// -----------------------------------------------------------------------------
+// 型定義
+
+export const AUTH_API_KEY = 'auth' as const
+export type AuthApiKey = typeof AUTH_API_KEY
+
+export type AuthContext = {
+  getDb: () => DataBase | null
+  setDb: (db: DataBase | null) => void
+}
+
+// -----------------------------------------------------------------------------
+// インターフェイス定義
+
+export type AuthApi = ApiInterface<{
+  getStatus: () => Promise<AuthStatus>
+  login: (username: string, password: string) => Promise<AuthStatus>
+  logout: () => Promise<void>
+}>
+
+// -----------------------------------------------------------------------------
+// 実装
+
+export function getAuthApi(
+  getContext: (webContents: WebContents) => AuthContext,
+): WithWebContentsApi<AuthApi> {
+  return {
+    getStatus: async (webContents) => {
+      const db = getContext(webContents).getDb()
+      if (!db) throw new Error('Auth DB is not initialized')
+      return getAuthStatus(db)
+    },
+
+    login: async (username, password, webContents) => {
+      const db = getContext(webContents).getDb()
+      if (!db) throw new Error('Auth DB is not initialized')
+      return loginService(db, username, password)
+    },
+
+    logout: async (webContents) => {
+      const db = getContext(webContents).getDb()
+      if (!db) throw new Error('Auth DB is not initialized')
+      logoutService(db)
+    },
+  }
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -6,13 +6,14 @@ import path from 'node:path'
 
 import { createContextMenu } from './windows/contextMenu'
 import { registerIpc } from './ipc/register'
-import { createAuthDb, ensureAuthDb } from './services/auth/authDb'
+import { createAuthRuntime } from './services/auth/authRuntime'
 
 import type { WebContents } from 'electron'
 import type { AiAgent } from './services/ai-agent/AiAgent'
 import type { McpServer } from './services/mcp'
 import type { DataBase } from './services/db/db'
 import type { Context as AppContext } from './ipc/register'
+import type { AuthRuntime } from './services/auth/authRuntime'
 
 // const require = createRequire(import.meta.url)
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -43,11 +44,10 @@ let win: BrowserWindow | null
 let aiAgent: AiAgent | null = null
 let mcpServer: McpServer | null = null
 let db: DataBase | null = null
-let authDb: DataBase | null = null
 const registerIpcCache = new WeakMap<WebContents, Map<string, () => void>>()
 const contextMap = new WeakMap<WebContents, AppContext>()
 
-function createWindow() {
+function createWindow(authRuntime: AuthRuntime) {
   const wind = new BrowserWindow({
     icon: path.join(process.env.VITE_PUBLIC, 'electron-vite.svg'),
     webPreferences: {
@@ -86,10 +86,7 @@ function createWindow() {
       },
     },
     auth: {
-      getDb: () => authDb,
-      setDb: (newDb: DataBase | null) => {
-        authDb = newDb
-      },
+      getRuntime: () => authRuntime,
     },
   })
 
@@ -116,25 +113,22 @@ app.on('window-all-closed', () => {
   }
 })
 
-app.on('before-quit', () => {
-  authDb?.close()
-  authDb = null
-})
-
-app.on('activate', () => {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow()
-  }
-})
-
 app.whenReady().then(() => {
   registerCustomProtocol()
 
-  // 起動時にユーザーデータ領域へ認証DBを準備する
-  authDb = createAuthDb()
-  ensureAuthDb(authDb)
+  const authRuntime = createAuthRuntime()
+
+  app.on('before-quit', () => {
+    authRuntime.dispose()
+  })
+
+  app.on('activate', () => {
+    // On OS X it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow(authRuntime)
+    }
+  })
 
   // IPC登録（window が load して renderer が invoke する前に必ず登録しておく）
   registerIpc({
@@ -147,5 +141,5 @@ app.whenReady().then(() => {
     cache: registerIpcCache,
   })
 
-  createWindow()
+  createWindow(authRuntime)
 })

--- a/electron/main/ipc/electronApi.ts
+++ b/electron/main/ipc/electronApi.ts
@@ -12,6 +12,7 @@ import type { McpApi, MCP_API_KEY } from '../features/mcp'
 import type { AiAgentApi, AI_AGENT_API_KEY } from '../features/aiAgent'
 import type { AiChatApi, AI_CHAT_API_KEY } from '../features/aiChat'
 import type { KakeiboApi, Kakeibo_API_KEY } from '../features/kakeibo'
+import type { AuthApi, AUTH_API_KEY } from '../features/auth'
 
 type ElectronRendererApi = {
   [FS_API_KEY]: FileSystemRendererApi
@@ -25,6 +26,7 @@ export type ElectronMainApi = {
   [AI_AGENT_API_KEY]: AiAgentApi
   [AI_CHAT_API_KEY]: AiChatApi
   [Kakeibo_API_KEY]: KakeiboApi
+  [AUTH_API_KEY]: AuthApi
 }
 
 const getPathForFile: FileSystemRendererApi['getPathForFile'] = async (
@@ -96,6 +98,11 @@ export const electronApi = createElectronApi<
       },
       kakeibo: {
         entries: useChannelAsInvoke('kakeibo.entries'),
+      },
+      auth: {
+        getStatus: useChannelAsInvoke('auth.getStatus'),
+        login: useChannelAsInvoke('auth.login'),
+        logout: useChannelAsInvoke('auth.logout'),
       },
     }),
   ({ defineHelper }) =>

--- a/electron/main/ipc/register.ts
+++ b/electron/main/ipc/register.ts
@@ -6,17 +6,20 @@ import { MCP_API_KEY, getMcpApi } from '../features/mcp'
 import { AI_AGENT_API_KEY, getAiAgentApi } from '../features/aiAgent'
 import { getAiChatApi } from '../features/aiChat'
 import { Kakeibo_API_KEY, getKakeiboApi } from '../features/kakeibo'
+import { AUTH_API_KEY, getAuthApi } from '../features/auth'
 
 import type { WebContents } from 'electron'
 import type { McpApiContext } from '../features/mcp'
 import type { AiAgentContext } from '../features/aiAgent'
 import type { KakeiboContext } from '../features/kakeibo'
+import type { AuthContext } from '../features/auth'
 import type { ElectronMainApi } from './electronApi'
 
 export type Context = {
   [MCP_API_KEY]: McpApiContext
   [AI_AGENT_API_KEY]: AiAgentContext
   [Kakeibo_API_KEY]: KakeiboContext
+  [AUTH_API_KEY]: AuthContext
 }
 
 export const registerIpc = createRegisterIpc<ElectronMainApi, Context>(
@@ -33,6 +36,9 @@ export const registerIpc = createRegisterIpc<ElectronMainApi, Context>(
     const aiChat = getAiChatApi()
     const kakeibo = getKakeiboApi(
       (webContents: WebContents) => getContext(webContents)[Kakeibo_API_KEY],
+    )
+    const auth = getAuthApi(
+      (webContents: WebContents) => getContext(webContents)[AUTH_API_KEY],
     )
 
     return defineHelper({
@@ -84,6 +90,9 @@ export const registerIpc = createRegisterIpc<ElectronMainApi, Context>(
       'aiChat.chat': { type: 'invoke', method: aiChat.chat },
       'aiChat.on.chunk': { type: 'event', addEventListener: aiChat.on.chunk },
       'kakeibo.entries': { type: 'invoke', method: kakeibo.entries },
+      'auth.getStatus': { type: 'invoke', method: auth.getStatus },
+      'auth.login': { type: 'invoke', method: auth.login },
+      'auth.logout': { type: 'invoke', method: auth.logout },
     })
   },
 )

--- a/electron/main/services/auth/authDb.ts
+++ b/electron/main/services/auth/authDb.ts
@@ -1,0 +1,94 @@
+import path from 'node:path'
+import { app } from 'electron'
+
+import { DataBase } from '../db/db'
+
+function getAuthDbPath() {
+  return path.join(app.getPath('userData'), 'auth.db')
+}
+
+export function createAuthDb(): DataBase {
+  const dbPath = getAuthDbPath()
+
+  console.log(`Auth DB Path: ${dbPath}`)
+
+  return new DataBase(dbPath)
+}
+
+export function ensureAuthDb(db: DataBase): void {
+  db.exec(
+    [
+      /**
+       * データベース全体の設定
+       * - foreign_keys: 外部キー制約を有効化
+       * - journal_mode: トランザクションログのモードをWALに設定
+       * - synchronous: データベースの同期モードをNORMALに設定
+       */
+      'PRAGMA foreign_keys = ON;',
+      'PRAGMA journal_mode = WAL;',
+      'PRAGMA synchronous = NORMAL;',
+
+      /**
+       * 認証ユーザーテーブル
+       * - id: ユーザーID（主キー、自動増分）
+       * - username: ユーザー名（一意制約付き）
+       * - password_hash: パスワードのハッシュ値
+       * - password_salt: パスワードのソルト値
+       * - password_kdf: パスワードのKDFアルゴリズム
+       * - password_kdf_params: KDFのパラメータ（JSON形式）
+       * - created_at: レコード作成日時
+       * - updated_at: レコード更新日時
+       * - disabled_at: ユーザー無効化日時（NULL可能）
+       *
+       * 解説:
+       * - password_saltはBLOB型で保存し、バイナリデータとして扱うことでセキュリティを向上させています。
+       * - password_kdf_paramsはJSON形式で保存し、将来的なKDFパラメータの拡張に対応できるようにしています。
+       * - disabled_atがNULLの場合、ユーザーは有効であり、値が設定されている場合は無効化されたことを示します。
+       *
+       * 補足事項:
+       * - ソルト（salt）とは、パスワードハッシュを生成する際に使用されるランダムなデータであり、同じパスワードでも異なるハッシュ値を生成するために利用されます。
+       * - KDF（Key Derivation Function）とは、パスワードから暗号鍵を生成するための関数であり、セキュリティ強化のために使用されます。
+       */
+      `CREATE TABLE IF NOT EXISTS auth_users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL UNIQUE,
+        password_hash TEXT NOT NULL,
+        password_salt BLOB NOT NULL,
+        password_kdf TEXT NOT NULL,
+        password_kdf_params TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        disabled_at TEXT
+      );`,
+
+      /**
+       * 認証セッションテーブル
+       * - id: セッションID（主キー、自動増分）
+       * - user_id: ユーザーID（外部キー、auth_usersテーブル参照）
+       * - is_current: 現在のセッションフラグ（1: 現在のセッション、0: 過去のセッション）
+       * - created_at: セッション作成日時
+       * - last_used_at: 最終使用日時
+       * - expires_at: セッション有効期限日時
+       * - revoked_at: セッション無効化日時（NULL可能）
+       */
+      `CREATE TABLE IF NOT EXISTS auth_sessions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        is_current INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        last_used_at TEXT,
+        expires_at TEXT NOT NULL,
+        revoked_at TEXT,
+        FOREIGN KEY(user_id) REFERENCES auth_users(id) ON DELETE CASCADE
+      );`,
+
+      /**
+       * インデックスの作成
+       * - ux_auth_sessions_current: 現在のセッションに対する一意インデックス
+       * - ix_auth_sessions_user_id: ユーザーIDに対するインデックス
+       */
+      'CREATE UNIQUE INDEX IF NOT EXISTS ux_auth_sessions_current ON auth_sessions(is_current) WHERE is_current = 1;',
+      'CREATE INDEX IF NOT EXISTS ix_auth_sessions_user_id ON auth_sessions(user_id);',
+    ].join('\n'),
+  )
+}

--- a/electron/main/services/auth/authRuntime.ts
+++ b/electron/main/services/auth/authRuntime.ts
@@ -1,0 +1,47 @@
+import { createAuthDb, ensureAuthDb } from './authDb'
+import { getAuthStatus, login, logout } from './authService'
+
+import type { AuthStatus } from './authService'
+
+export type AuthRuntime = {
+  getStatus: () => AuthStatus
+  login: (username: string, password: string) => AuthStatus
+  logout: () => void
+  dispose: () => void
+}
+
+export function createAuthRuntime(): AuthRuntime {
+  const db = createAuthDb()
+  ensureAuthDb(db)
+
+  let disposed = false
+
+  const ensureNotDisposed = () => {
+    if (disposed) {
+      throw new Error('AuthRuntime is disposed')
+    }
+  }
+
+  return {
+    getStatus: () => {
+      ensureNotDisposed()
+      return getAuthStatus(db)
+    },
+
+    login: (username, password) => {
+      ensureNotDisposed()
+      return login(db, username, password)
+    },
+
+    logout: () => {
+      ensureNotDisposed()
+      return logout(db)
+    },
+
+    dispose: () => {
+      if (disposed) return
+      disposed = true
+      db.close()
+    },
+  }
+}

--- a/electron/main/services/auth/authService.ts
+++ b/electron/main/services/auth/authService.ts
@@ -1,0 +1,231 @@
+import crypto from 'node:crypto'
+
+import type { DataBase } from '../db/db'
+
+export type AuthUser = {
+  username: string
+}
+
+export type AuthStatus = {
+  isAuthenticated: boolean
+  user: AuthUser | null
+}
+
+type DbAuthUser = {
+  id: number
+  username: string
+  password_hash: string
+  password_salt: Buffer
+  password_kdf_params: string
+  disabled_at: string | null
+}
+
+type DbAuthSessionWithUser = {
+  username: string
+  expires_at: string
+}
+
+const DEFAULT_SESSION_YEARS = 10
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function computeExpiresAtIso() {
+  const d = new Date()
+  d.setFullYear(d.getFullYear() + DEFAULT_SESSION_YEARS)
+  return d.toISOString()
+}
+
+function createPasswordRecord(password: string) {
+  const salt = crypto.randomBytes(16)
+
+  const params = {
+    kdf: 'scrypt',
+    cost: 16384,
+    blockSize: 8,
+    parallelization: 1,
+    keylen: 64,
+  } as const
+
+  const hash = crypto
+    .scryptSync(password, salt, params.keylen, {
+      cost: params.cost,
+      blockSize: params.blockSize,
+      parallelization: params.parallelization,
+    })
+    .toString('hex')
+
+  return {
+    passwordHash: hash,
+    passwordSalt: salt,
+    passwordKdf: params.kdf,
+    passwordKdfParams: JSON.stringify(params),
+  }
+}
+
+function verifyPassword(password: string, user: DbAuthUser) {
+  const params = JSON.parse(user.password_kdf_params) as {
+    kdf: string
+    cost: number
+    blockSize: number
+    parallelization: number
+    keylen: number
+  }
+
+  if (params.kdf !== 'scrypt') return false
+
+  const hash = crypto
+    .scryptSync(password, user.password_salt, params.keylen, {
+      cost: params.cost,
+      blockSize: params.blockSize,
+      parallelization: params.parallelization,
+    })
+    .toString('hex')
+
+  const a = Buffer.from(hash, 'hex')
+  const b = Buffer.from(user.password_hash, 'hex')
+  if (a.length !== b.length) return false
+
+  return crypto.timingSafeEqual(a, b)
+}
+
+function revokeCurrentSession(db: DataBase, revokedAt: string) {
+  db.run(
+    'UPDATE auth_sessions SET revoked_at = ?, is_current = 0 WHERE is_current = 1 AND revoked_at IS NULL',
+    [revokedAt],
+  )
+}
+
+function createCurrentSession(db: DataBase, userId: number) {
+  const createdAt = nowIso()
+  const expiresAt = computeExpiresAtIso()
+
+  db.run(
+    'INSERT INTO auth_sessions (user_id, is_current, created_at, last_used_at, expires_at, revoked_at) VALUES (?, 1, ?, ?, ?, NULL)',
+    [userId, createdAt, createdAt, expiresAt],
+  )
+}
+
+function readCurrentSessionUser(
+  db: DataBase,
+): DbAuthSessionWithUser | undefined {
+  return db.get<DbAuthSessionWithUser>(
+    [
+      'SELECT u.username as username, s.expires_at as expires_at',
+      'FROM auth_sessions s',
+      'JOIN auth_users u ON u.id = s.user_id',
+      'WHERE s.is_current = 1 AND s.revoked_at IS NULL AND u.disabled_at IS NULL',
+      'LIMIT 1',
+    ].join('\n'),
+  )
+}
+
+export function getAuthStatus(db: DataBase): AuthStatus {
+  const row = readCurrentSessionUser(db)
+  if (!row) {
+    return { isAuthenticated: false, user: null }
+  }
+
+  if (Number.isNaN(Date.parse(row.expires_at))) {
+    return { isAuthenticated: false, user: null }
+  }
+
+  if (Date.parse(row.expires_at) <= Date.now()) {
+    return { isAuthenticated: false, user: null }
+  }
+
+  db.run(
+    'UPDATE auth_sessions SET last_used_at = ? WHERE is_current = 1 AND revoked_at IS NULL',
+    [nowIso()],
+  )
+
+  return {
+    isAuthenticated: true,
+    user: { username: row.username },
+  }
+}
+
+export function login(
+  db: DataBase,
+  username: string,
+  password: string,
+): AuthStatus {
+  const normalized = username.trim()
+  if (!normalized) {
+    throw new Error('username is required')
+  }
+
+  db.exec('BEGIN IMMEDIATE')
+  try {
+    const existing = db.get<DbAuthUser>(
+      [
+        'SELECT id, username, password_hash, password_salt, password_kdf_params, disabled_at',
+        'FROM auth_users',
+        'WHERE username = ?',
+        'LIMIT 1',
+      ].join('\n'),
+      [normalized],
+    )
+
+    let userId: number
+
+    if (!existing) {
+      const createdAt = nowIso()
+      const record = createPasswordRecord(password)
+
+      db.run(
+        [
+          'INSERT INTO auth_users (username, password_hash, password_salt, password_kdf, password_kdf_params, created_at, updated_at, disabled_at)',
+          'VALUES (?, ?, ?, ?, ?, ?, ?, NULL)',
+        ].join('\n'),
+        [
+          normalized,
+          record.passwordHash,
+          record.passwordSalt,
+          record.passwordKdf,
+          record.passwordKdfParams,
+          createdAt,
+          createdAt,
+        ],
+      )
+
+      const createdUser = db.get<{ id: number }>(
+        'SELECT id FROM auth_users WHERE username = ? LIMIT 1',
+        [normalized],
+      )
+      if (!createdUser) {
+        throw new Error('failed to create user')
+      }
+      userId = createdUser.id
+    } else {
+      if (existing.disabled_at) {
+        throw new Error('user is disabled')
+      }
+
+      const ok = verifyPassword(password, existing)
+      if (!ok) {
+        throw new Error('invalid username or password')
+      }
+
+      userId = existing.id
+    }
+
+    revokeCurrentSession(db, nowIso())
+    createCurrentSession(db, userId)
+
+    db.exec('COMMIT')
+  } catch (e) {
+    db.exec('ROLLBACK')
+    throw e
+  }
+
+  return {
+    isAuthenticated: true,
+    user: { username: normalized },
+  }
+}
+
+export function logout(db: DataBase): void {
+  revokeCurrentSession(db, nowIso())
+}

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+
+export type AuthUser = {
+  username: string
+}
+
+export type AuthState = {
+  isAuthenticated: boolean
+  user: AuthUser | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+type AuthContextValue = {
+  auth: AuthState
+}
+
+const AuthContext = React.createContext<AuthContextValue | undefined>(undefined)
+
+const STORAGE_KEY = 'demo-auth-user'
+
+export function AuthProvider(props: { children: React.ReactNode }) {
+  const { children } = props
+
+  const [user, setUser] = React.useState<AuthUser | null>(null)
+  const [isLoading, setIsLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (raw) {
+        const parsed = JSON.parse(raw) as AuthUser
+        if (parsed.username) {
+          setUser({ username: parsed.username })
+        }
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  const login = React.useCallback(
+    async (username: string, _password: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      const nextUser: AuthUser = { username }
+      setUser(nextUser)
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(nextUser))
+    },
+    [],
+  )
+
+  const logout = React.useCallback(() => {
+    setUser(null)
+    localStorage.removeItem(STORAGE_KEY)
+  }, [])
+
+  const auth = React.useMemo<AuthState>(() => {
+    return {
+      isAuthenticated: Boolean(user),
+      user,
+      login,
+      logout,
+    }
+  }, [login, logout, user])
+
+  if (isLoading) {
+    return (
+      <div className="h-screen w-full grid place-items-center">
+        <div className="text-sm text-muted-foreground">Loading...</div>
+      </div>
+    )
+  }
+
+  return (
+    <AuthContext.Provider value={{ auth }}>{children}</AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = React.useContext(AuthContext)
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return ctx
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -5,11 +5,13 @@ import {
   Command,
   Frame,
   GalleryVerticalEnd,
+  LogInIcon,
   Map,
   Pickaxe,
   PieChart,
   SquareTerminal,
 } from 'lucide-react'
+import { Link, useLocation } from '@tanstack/react-router'
 
 import { NavMain } from '@/components/nav-main'
 import { NavProjects } from '@/components/nav-projects'
@@ -20,8 +22,12 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
   SidebarRail,
 } from '@/components/ui/sidebar'
+import { useAuth } from '@/auth'
 
 // This is sample data.
 const data = {
@@ -137,6 +143,12 @@ const data = {
 }
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const {
+    auth: { isAuthenticated, user, logout },
+  } = useAuth()
+
+  const location = useLocation()
+
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
@@ -147,7 +159,34 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <NavProjects projects={data.projects} />
       </SidebarContent>
       <SidebarFooter>
-        <NavUser user={data.user} />
+        {isAuthenticated ? (
+          <NavUser
+            user={{
+              name: user?.username || 'Unknown',
+              email: `${user?.username || 'unknown@example.com'}`,
+              avatar: '',
+            }}
+            logout={logout}
+          />
+        ) : (
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild>
+                <Link
+                  className="bg-sidebar-accent text-sidebar-accent-foreground flex w-full items-center rounded-lg px-3 py-2 text-sm font-medium hover:bg-sidebar-accent/80"
+                  to="/login"
+                  search={{
+                    redirect: location.href,
+                  }}
+                  disabled={location.pathname === '/login'}
+                >
+                  <LogInIcon className="mr-2 h-4 w-4" />
+                  Login
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        )}
       </SidebarFooter>
       <SidebarRail />
     </Sidebar>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -27,7 +27,7 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from '@/components/ui/sidebar'
-import { useAuth } from '@/auth'
+import { useAuth } from '@/features/auth/api/auth'
 
 // This is sample data.
 const data = {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,7 +8,7 @@ import {
   SidebarTrigger,
 } from '@/components/ui/sidebar'
 import { OpenChat } from '@/features/chat/components/open-chat'
-import { useAuth } from '@/auth'
+import { useAuth } from '@/features/auth/api/auth'
 
 export function Layout(props: { children?: React.ReactNode }) {
   const { children } = props

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,9 +8,11 @@ import {
   SidebarTrigger,
 } from '@/components/ui/sidebar'
 import { OpenChat } from '@/features/chat/components/open-chat'
+import { useAuth } from '@/auth'
 
 export function Layout(props: { children?: React.ReactNode }) {
   const { children } = props
+  const { auth } = useAuth()
 
   return (
     <SidebarProvider>
@@ -26,7 +28,7 @@ export function Layout(props: { children?: React.ReactNode }) {
         <SiteHeader />
         <div className="w-full h-full overflow-auto">{children}</div>
       </SidebarInset>
-      <OpenChat />
+      {auth.isAuthenticated && <OpenChat />}
     </SidebarProvider>
   )
 }

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   BadgeCheck,
   Bell,
@@ -28,14 +26,18 @@ import {
 
 export function NavUser({
   user,
+  logout,
 }: {
   user: {
     name: string
     email: string
     avatar: string
   }
+  logout: () => void
 }) {
   const { isMobile } = useSidebar()
+
+  const avatarAlt = user.name.slice(0, 2).toUpperCase()
 
   return (
     <SidebarMenu>
@@ -48,7 +50,9 @@ export function NavUser({
             >
               <Avatar className="h-8 w-8 rounded-lg">
                 <AvatarImage src={user.avatar} alt={user.name} />
-                <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                <AvatarFallback className="rounded-lg">
+                  {avatarAlt}
+                </AvatarFallback>
               </Avatar>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{user.name}</span>
@@ -67,7 +71,9 @@ export function NavUser({
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <Avatar className="h-8 w-8 rounded-lg">
                   <AvatarImage src={user.avatar} alt={user.name} />
-                  <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                  <AvatarFallback className="rounded-lg">
+                    {avatarAlt}
+                  </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-medium">{user.name}</span>
@@ -98,7 +104,7 @@ export function NavUser({
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem>
+            <DropdownMenuItem onClick={logout}>
               <LogOut />
               Log out
             </DropdownMenuItem>

--- a/src/electronApi.ts
+++ b/src/electronApi.ts
@@ -6,8 +6,29 @@ export const electronApi: ElectronApi = (() => {
   if (isElectron) {
     return window.electronApi
   } else {
+    let mockUser: { username: string } | null = null
+
     // Mock implementation for non-Electron environments
     return {
+      auth: {
+        getStatus: async () =>
+          Promise.resolve({
+            isAuthenticated: Boolean(mockUser),
+            user: mockUser,
+          }),
+        // eslint-disable-next-line @typescript-eslint/require-await
+        login: async (username: string, _password: string) => {
+          mockUser = { username }
+          return {
+            isAuthenticated: true,
+            user: mockUser,
+          }
+        },
+        // eslint-disable-next-line @typescript-eslint/require-await
+        logout: async () => {
+          mockUser = null
+        },
+      },
       theme: {
         setTheme: () => Promise.resolve(),
         getTheme: () => Promise.resolve('light' as const),

--- a/src/features/auth/api/auth.tsx
+++ b/src/features/auth/api/auth.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { electronApi } from './electronApi'
+import { electronApi } from '@/electronApi'
 
 export type AuthUser = {
   username: string
@@ -26,18 +26,24 @@ export function AuthProvider(props: { children: React.ReactNode }) {
 
   React.useEffect(() => {
     let cancelled = false
-    ;(async () => {
+
+    const load = async () => {
       try {
         const status = await electronApi.auth.getStatus()
-        if (!cancelled) {
-          setUser(status.user)
-        }
+        if (cancelled) return
+        setUser(status.user)
+      } catch (e) {
+        if (cancelled) return
+        console.error(e)
+        setUser(null)
       } finally {
         if (!cancelled) {
           setIsLoading(false)
         }
       }
-    })()
+    }
+
+    void load()
 
     return () => {
       cancelled = true

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ import { routeTree } from './routeTree.gen'
 import reportWebVitals from './reportWebVitals.ts'
 import { ThemeProvider } from '@/components/theme-provider'
 import { DevToolsProvider } from '@/components/devtools-provider.tsx'
-import { AuthProvider, useAuth } from '@/auth'
+import { AuthProvider, useAuth } from '@/features/auth/api/auth'
 
 // 生成されたルートツリーをインポート
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as DemoRouteRouteImport } from './routes/demo.route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DemoIndexRouteImport } from './routes/demo.index'
@@ -20,6 +21,11 @@ import { Route as DemoFsRouteImport } from './routes/demo.fs'
 import { Route as DemoChatTRouteImport } from './routes/demo.chat-t'
 import { Route as DemoChatRouteImport } from './routes/demo.chat'
 
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DemoRouteRoute = DemoRouteRouteImport.update({
   id: '/demo',
   path: '/demo',
@@ -74,6 +80,7 @@ const DemoChatRoute = DemoChatRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/demo': typeof DemoRouteRouteWithChildren
+  '/login': typeof LoginRoute
   '/demo/chat': typeof DemoChatRoute
   '/demo/chat-t': typeof DemoChatTRoute
   '/demo/fs': typeof DemoFsRoute
@@ -85,6 +92,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/demo/chat': typeof DemoChatRoute
   '/demo/chat-t': typeof DemoChatTRoute
   '/demo/fs': typeof DemoFsRoute
@@ -98,6 +106,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/demo': typeof DemoRouteRouteWithChildren
+  '/login': typeof LoginRoute
   '/demo/chat': typeof DemoChatRoute
   '/demo/chat-t': typeof DemoChatTRoute
   '/demo/fs': typeof DemoFsRoute
@@ -112,6 +121,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/demo'
+    | '/login'
     | '/demo/chat'
     | '/demo/chat-t'
     | '/demo/fs'
@@ -123,6 +133,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/login'
     | '/demo/chat'
     | '/demo/chat-t'
     | '/demo/fs'
@@ -135,6 +146,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/demo'
+    | '/login'
     | '/demo/chat'
     | '/demo/chat-t'
     | '/demo/fs'
@@ -148,10 +160,18 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DemoRouteRoute: typeof DemoRouteRouteWithChildren
+  LoginRoute: typeof LoginRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/demo': {
       id: '/demo'
       path: '/demo'
@@ -254,6 +274,7 @@ const DemoRouteRouteWithChildren = DemoRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DemoRouteRoute: DemoRouteRouteWithChildren,
+  LoginRoute: LoginRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,7 +9,7 @@ import TanStackQueryDevtools from '../integrations/tanstack-query/devtools'
 
 import type { QueryClient } from '@tanstack/react-query'
 
-import type { AuthState } from '@/auth'
+import type { AuthState } from '@/features/auth/api/auth'
 import { useDevTools } from '@/components/devtools-provider'
 
 interface MyRouterContext {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,10 +9,12 @@ import TanStackQueryDevtools from '../integrations/tanstack-query/devtools'
 
 import type { QueryClient } from '@tanstack/react-query'
 
+import type { AuthState } from '@/auth'
 import { useDevTools } from '@/components/devtools-provider'
 
 interface MyRouterContext {
   queryClient: QueryClient
+  auth: AuthState
 }
 
 export const Route = createRootRouteWithContext<MyRouterContext>()({

--- a/src/routes/demo.route.tsx
+++ b/src/routes/demo.route.tsx
@@ -1,6 +1,16 @@
-import { Outlet, createFileRoute } from '@tanstack/react-router'
+import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/demo')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({
+        to: '/login',
+        search: {
+          redirect: location.href,
+        },
+      })
+    }
+  },
   component: RouteComponent,
   loader: () => ({ crumb: 'Demo' }),
 })

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react'
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+
+type LoginSearch = {
+  redirect?: string
+}
+
+export const Route = createFileRoute('/login')({
+  validateSearch: (search: LoginSearch) => ({
+    redirect: typeof search.redirect === 'string' ? search.redirect : '/',
+  }),
+  beforeLoad: ({ context, search }) => {
+    if (context.auth.isAuthenticated) {
+      throw redirect({ to: search.redirect })
+    }
+  },
+  component: LoginRouteComponent,
+})
+
+function LoginRouteComponent() {
+  const { auth } = Route.useRouteContext()
+  const { redirect: redirectTo } = Route.useSearch()
+  const navigate = useNavigate()
+
+  const [username, setUsername] = React.useState('demo')
+  const [password, setPassword] = React.useState('')
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  return (
+    <div className="h-full min-h-[calc(100vh-var(--header-height,0px))] grid place-items-center p-6">
+      <form
+        className="w-full max-w-sm space-y-4 rounded-lg border bg-background p-6"
+        onSubmit={async (e) => {
+          e.preventDefault()
+          setIsLoading(true)
+          setError(null)
+
+          try {
+            await auth.login(username, password)
+            await navigate({ to: redirectTo })
+          } catch {
+            setError('ログインに失敗しました')
+          } finally {
+            setIsLoading(false)
+          }
+        }}
+      >
+        <div className="space-y-1">
+          <h1 className="text-lg font-semibold">Login</h1>
+          <p className="text-sm text-muted-foreground">
+            Demo認証: 何を入れてもOK（ローカル保存）
+          </p>
+        </div>
+
+        {error ? <div className="text-sm text-destructive">{error}</div> : null}
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium" htmlFor="username">
+            Username
+          </label>
+          <input
+            id="username"
+            className="w-full rounded border bg-background px-3 py-2 text-sm"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium" htmlFor="password">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            className="w-full rounded border bg-background px-3 py-2 text-sm"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full rounded bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {isLoading ? 'Signing in...' : 'Sign In'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -49,7 +49,8 @@ function LoginRouteComponent() {
         <div className="space-y-1">
           <h1 className="text-lg font-semibold">Login</h1>
           <p className="text-sm text-muted-foreground">
-            Demo認証: 何を入れてもOK（ローカル保存）
+            オフライン認証: 初回はユーザー作成、その後はパスワード検証（SQLite /
+            Main管理）
           </p>
         </div>
 


### PR DESCRIPTION
## 概要
- Electron(Main)管理のオフライン認証を追加し、未ログイン時は `/login` に誘導する導線を実装しました。

## 変更内容
- 認証基盤（Main）
  - `auth.db`（`app.getPath('userData')` 配下）にユーザー/セッションを保存
  - パスワードは `scrypt` + `timingSafeEqual` で検証
  - IPC: `auth.getStatus` / `auth.login` / `auth.logout` を追加
- 認証UI（Renderer）
  - `AuthProvider` を追加し、起動時に `getStatus` で認証状態を復元
  - `/demo` を保護し、未認証なら `/login?redirect=...` にリダイレクト
  - `/login` 画面を追加（成功後は `redirect` に戻る）
  - サイドバーにログイン/ログアウト導線を追加（ログアウト時は保護エリアから退避）

## 影響範囲
- 認証/セッション管理（新規DB作成、IPC追加、ルーティングガード）
- `electronApi` の型・mock 実装（非Electron環境用の `auth` が追加）

## 動作確認
- [x] `pnpm test` が成功する
- [x] `pnpm dev` で起動できる
- [x] `pnpm build` でビルドして exe を起動できる

## レビュー観点
- セキュリティ/仕様
  - セッション有効期限が「10年」設定になっている点が要件通りか
  - 初回ログイン時にユーザーを自動作成する挙動が想定通りか（運用/UX観点）
- データ整合性
  - `auth_sessions` の「current一意」制約と、ログイン/ログアウト時の更新が妥当か
- 画面遷移
  - `/demo` 配下のガード、`redirect` パラメータ、ログアウト時の強制遷移が期待通りか

## 関連リンク
- なし