### PR TITLE
fix(chat): ダイアログを閉じてもチャット状態を保持する

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,4 @@ src/hooks/use-mobile.ts
 src/lib/utils.ts
 src/styles/**
 src/styles.css
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,242 @@
+# AGENTS.md
+
+This repo is an Electron + Vite + React + TypeScript template.
+Use this file as the operating manual for agentic coding tools working here.
+
+Checked for additional agent rules:
+
+- `.cursor/rules/`: not present
+- `.cursorrules`: not present
+- `.github/copilot-instructions.md`: not present
+
+## Core Commands (pnpm)
+
+Install:
+
+- `pnpm install`
+
+Dev (Vite + Electron via vite-plugin-electron):
+
+- `pnpm dev`
+
+Build (renderer + typecheck + package):
+
+- `pnpm build`
+  - runs: `vite build && tsc && electron-builder`
+
+Preview built renderer:
+
+- `pnpm serve` (Vite preview)
+
+Typecheck + tests:
+
+- `pnpm test`
+  - runs: `tsc --noEmit && vitest run`
+
+Typecheck + lint:
+
+- `pnpm lint`
+  - runs: `tsc --noEmit && eslint`
+
+Format:
+
+- `pnpm format` (Prettier write)
+
+Autofix (typecheck + format + eslint fix):
+
+- `pnpm check`
+  - runs: `tsc --noEmit && prettier --write . && eslint --fix`
+
+Notes:
+
+- `postinstall` runs `electron-builder install-app-deps` (native deps like better-sqlite3).
+- Generated/build outputs: `dist/`, `dist-electron/`, `release/`.
+
+## Running A Single Test (Vitest)
+
+The `pnpm test` script always runs a full typecheck first. For fast iteration, call
+Vitest directly.
+
+Run one test file:
+
+- `pnpm vitest run src/components/table/debounced-input.test.tsx`
+- `pnpm vitest run electron/shared/lib/ipc/browser/deepMerge.test.ts`
+
+Run tests matching a name pattern:
+
+- `pnpm vitest run -t "DebouncedInput"`
+- `pnpm vitest run -t "deepMerge"`
+
+Watch mode for a single file:
+
+- `pnpm vitest src/components/table/debounced-input.test.tsx`
+
+Run with a UI-less, deterministic run (CI-like):
+
+- `pnpm vitest run --reporter=default`
+
+If you need typecheck only:
+
+- `pnpm tsc --noEmit`
+
+## Lint / Format (Single File)
+
+Lint a subset:
+
+- `pnpm eslint src/routes/(app)/demo.table.tsx`
+- `pnpm eslint electron/main/index.ts`
+
+Autofix a subset:
+
+- `pnpm eslint --fix src/routes/(app)/demo.table.tsx`
+
+Format a subset:
+
+- `pnpm prettier --write src/routes/(app)/demo.table.tsx`
+
+## Project Layout
+
+- `src/`: renderer (React + TanStack Router/Query, Tailwind)
+- `electron/main/`: Electron main process (windows, IPC handlers, DB, MCP, auth)
+- `electron/preload/`: preload script, exposes `window.api`
+- `electron/shared/`: shared libs (typed IPC framework used by main + renderer)
+
+Aliases (see `tsconfig.json`):
+
+- `@/*` -> `src/*`
+- `#/*` -> `electron/*`
+
+## Tooling Configuration (What Agents Must Follow)
+
+TypeScript (`tsconfig.json`):
+
+- `strict: true`
+- `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`: on
+- `moduleResolution: bundler`, `verbatimModuleSyntax: true`
+- `allowImportingTsExtensions: true`
+- `noUncheckedSideEffectImports: true` (avoid side-effect imports unless required)
+
+ESLint (`eslint.config.js`):
+
+- Uses `@tanstack/eslint-config` as the base.
+- React hooks rules enabled via `eslint-plugin-react-hooks`.
+- React Compiler compatibility:
+  - `eslint-plugin-use-no-memo` is enabled.
+  - Rules:
+    - `use-no-memo/react-hook-form`: error
+    - `use-no-memo/tanstack-table`: error
+- Some paths are ignored by ESLint (not exhaustive):
+  - `dist-electron/**`
+  - `src/components/ui/**` (vendored/shadcn-like components)
+  - `src/lib/utils.ts`
+  - `src/features/ui-demo/**`
+  - `electron/**` (note: still keep code clean; just know lint may not catch it)
+
+Prettier (`prettier.config.js`):
+
+- `semi: false`
+- `singleQuote: true`
+- `trailingComma: all`
+
+EditorConfig (`.editorconfig`):
+
+- indent: spaces
+- line endings: LF
+- final newline: required
+
+## Code Style Guidelines
+
+### Imports
+
+- Prefer ESM imports; this repo uses `"type": "module"`.
+- Use `import type { ... } from '...'` for type-only imports.
+- Group imports by origin and keep them stable:
+  - node builtins
+  - external packages
+  - internal aliases (`@/`, `#/`)
+  - relative imports
+  - side-effect imports (CSS) last
+- Keep path aliases consistent:
+  - renderer code should prefer `@/..`
+  - Electron code should prefer `#/..`
+
+### Formatting
+
+- Let Prettier do the work; do not hand-format around it.
+- Keep line breaks similar to existing files (this repo commonly wraps long call
+  arguments and JSX props onto multiple lines).
+
+### Types and API boundaries
+
+- Keep types explicit at boundaries:
+  - IPC APIs (`electron/shared/lib/ipc/**`)
+  - public functions exported from feature modules
+  - data returned from Electron main to renderer
+- Prefer `unknown` over `any` for untrusted inputs, then narrow.
+- Use `Awaited<ReturnType<...>>` for deriving async return shapes (already used
+  in `src/api.ts`).
+
+### Naming
+
+- React components: `PascalCase`.
+- Hooks: `useX`.
+- Functions/vars: `camelCase`.
+- Types/interfaces: `PascalCase`.
+- Constants: `SCREAMING_SNAKE_CASE` when truly constant; otherwise `camelCase`.
+
+### React Compiler / "use no memo" directive
+
+This repo uses React Compiler (via Babel) in non-sourcemap builds and enforces
+opt-out directives for incompatible libraries.
+
+- If a component uses TanStack Table (`useReactTable`) or React Hook Form
+  (`useForm` etc.) and ESLint flags it, add this directive at the top of the
+  component function body:
+
+```ts
+function MyComponent() {
+  'use no memo'
+  // ...
+}
+```
+
+- Prefer the directive over disabling lint rules.
+- If you must disable, keep the scope minimal and include a reason.
+
+### Error handling
+
+- Fail fast with actionable messages at boundaries.
+- In Electron main, prefer `try/catch` around IO and initialization, log with
+  context, then rethrow (see `electron/main/index.ts` DB open handling).
+- In IPC invoke handlers, only throw serializable errors; do not throw raw
+  objects.
+
+### Side effects
+
+- Avoid side-effect imports to satisfy `noUncheckedSideEffectImports`.
+- Allowed side effects include app entrypoints and CSS:
+  - `src/main.tsx` imports `./styles.css` and `./custom.css`.
+
+## Testing Conventions
+
+- Vitest is configured in `vite.config.ts`:
+  - environment: `jsdom`
+  - globals: `true`
+- Test file naming seen in repo:
+  - `*.test.ts`, `*.test.tsx`
+- Prefer Testing Library for React component tests (`@testing-library/react`).
+- Use fake timers only when needed and always restore (`vi.useRealTimers()`).
+
+## Electron + IPC Notes (Common Pitfalls)
+
+- `electron/preload/index.ts` exposes `window.api` via `contextBridge`.
+- Renderer code should not import Electron directly; go through `window.api` or
+  through `src/api.ts` which provides a mock/non-Electron fallback.
+- IPC registration is centralized in `electron/main/ipc/registerIpc.ts` and uses
+  the typed IPC framework under `electron/shared/lib/ipc/**`.
+
+## What Not To Touch
+
+- Do not commit generated output folders (`dist/`, `dist-electron/`, `release/`).
+- `src/components/ui/**` is vendored UI code; keep changes minimal and prefer
+  extending via wrappers instead of rewriting.

--- a/src/features/chat/components/chat-session-provider.tsx
+++ b/src/features/chat/components/chat-session-provider.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react'
+import { useChat } from '@tanstack/ai-react'
+import { clientTools } from '@tanstack/ai-client'
+
+import { clockTool } from '../api/tools/tools'
+
+import type { Model } from '#/main/features/chat/ollama/models'
+import type { UIMessage } from '@tanstack/ai-client'
+
+import { fetchIpcEvents } from '@/lib/fetchIpcEvents'
+import { mcp } from '@/api'
+
+type ChatSessionValue = {
+  input: string
+  setInput: React.Dispatch<React.SetStateAction<string>>
+  // ツールのジェネリクスをアプリ全体に配管することなく変更できるように、
+  // これらは意図的に広く保ちます。
+  messages: Array<UIMessage>
+  sendMessage: (content: string) => Promise<void>
+  isLoading: boolean
+  stop: () => void
+  status: ReturnType<typeof useChat>['status']
+}
+
+const ChatSessionContext = React.createContext<ChatSessionValue | null>(null)
+
+export type ChatSessionProviderProps = {
+  model?: Model
+  children: React.ReactNode
+}
+
+export function ChatSessionProvider(props: ChatSessionProviderProps) {
+  const { model = 'gpt-oss:20b-cloud', children } = props
+
+  const connection = React.useMemo(() => fetchIpcEvents(), [])
+  const tools = React.useMemo(() => clientTools(clockTool), [])
+
+  React.useEffect(() => {
+    ;(async () => {
+      const status = await mcp.getServerStatus()
+      if (!status.isRunning) {
+        mcp.startServer({})
+      }
+    })()
+  }, [])
+
+  const chat = useChat({
+    connection,
+    tools,
+    body: {
+      model,
+    },
+  })
+
+  const [input, setInput] = React.useState('')
+
+  const value = React.useMemo<ChatSessionValue>(() => {
+    return {
+      input,
+      setInput,
+      messages: chat.messages as Array<UIMessage>,
+      sendMessage: chat.sendMessage as (content: string) => Promise<void>,
+      isLoading: chat.isLoading,
+      stop: chat.stop,
+      status: chat.status,
+    }
+  }, [
+    chat.isLoading,
+    chat.messages,
+    chat.sendMessage,
+    chat.status,
+    chat.stop,
+    input,
+  ])
+
+  return (
+    <ChatSessionContext.Provider value={value}>
+      {children}
+    </ChatSessionContext.Provider>
+  )
+}
+
+export function useChatSession() {
+  const ctx = React.useContext(ChatSessionContext)
+  if (!ctx) {
+    throw new Error(
+      'useChatSession must be used within <ChatSessionProvider />',
+    )
+  }
+  return ctx
+}

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -1,14 +1,8 @@
-import { useEffect, useState } from 'react'
-import { useChat } from '@tanstack/ai-react'
-import { clientTools } from '@tanstack/ai-client'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ArrowUpIcon, BotIcon, SquareIcon, User2Icon } from 'lucide-react'
 
-import { clockTool } from '../api/tools/tools'
-import type { Model } from '#/main/features/chat/ollama/models'
-import { fetchIpcEvents } from '@/lib/fetchIpcEvents'
-import { mcp } from '@/api'
+import { useChatSession } from '@/features/chat/components/chat-session-provider'
 import {
   Accordion,
   AccordionContent,
@@ -37,34 +31,14 @@ import {
 } from '@/components/ui/input-group'
 import { useAutoScrollToBottom } from '@/hooks/use-auto-scroll-to-bottom'
 
-export type ChatProps = {
-  model?: Model
-}
-
-export function Chat(props: ChatProps) {
-  const { model = 'gpt-oss:20b-cloud' } = props
+export function Chat() {
   const {
     auth: { user },
   } = useAuth()
   const username = user?.username || 'あなた'
 
-  useEffect(() => {
-    ;(async () => {
-      const status = await mcp.getServerStatus()
-      if (!status.isRunning) {
-        mcp.startServer({})
-      }
-    })()
-  }, [])
-
-  const [input, setInput] = useState('')
-  const { messages, sendMessage, isLoading, stop, status } = useChat({
-    connection: fetchIpcEvents(),
-    tools: clientTools(clockTool),
-    body: {
-      model,
-    },
-  })
+  const { input, setInput, messages, sendMessage, isLoading, stop, status } =
+    useChatSession()
 
   const { scrollContainerRef, scrollBottomRef, onScroll } =
     useAutoScrollToBottom([messages])

--- a/src/features/chat/components/open-chat.tsx
+++ b/src/features/chat/components/open-chat.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Chat } from '@/features/chat/components/chat'
+import { ChatSessionProvider } from '@/features/chat/components/chat-session-provider'
 import { Button } from '@/components/ui/button'
 
 export function OpenChat() {
@@ -33,68 +34,70 @@ export function OpenChat() {
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <Dialog modal={false}>
-          <DialogTrigger asChild>
-            <SidebarMenuButton
-              variant="outline"
-              className="bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-            >
-              <BotIcon />
-              <span>AIチャット</span>
-            </SidebarMenuButton>
-          </DialogTrigger>
+        <ChatSessionProvider model={selectedModel}>
+          <Dialog modal={false}>
+            <DialogTrigger asChild>
+              <SidebarMenuButton
+                variant="outline"
+                className="bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              >
+                <BotIcon />
+                <span>AIチャット</span>
+              </SidebarMenuButton>
+            </DialogTrigger>
 
-          <DialogContent
-            showCloseButton={false}
-            className="top-[calc(var(--header-height)+var(--spacing,0.25rem)*2)] left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md border border-primary shadow-lg shadow-primary/30 hover:shadow-primary/50"
-            // ダイアログ外クリックで閉じないようにする
-            onInteractOutside={(e) => e.preventDefault()}
-            // ダイアログ外クリックで閉じないようにする
-            onPointerDownOutside={(e) => e.preventDefault()}
-            // ESC キーで閉じないようにする
-            onEscapeKeyDown={(e) => e.preventDefault()}
-          >
-            <DialogHeader>
-              <DialogTitle className="flex items-center justify-between">
-                <div className="flex items-center justify-start text-lg font-semibold gap-1">
-                  <BotIcon />
-                  <span>AIチャット</span>
-                </div>
-                <div className="flex items-center justify-end  gap-1">
-                  <Select
-                    onValueChange={(value) =>
-                      setSelectedModel(modelSchema.parse(value))
-                    }
-                    value={selectedModel}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="モデル選択" />
-                    </SelectTrigger>
-                    <SelectContent position="popper">
-                      <SelectGroup>
-                        {MODELS.map((model) => (
-                          <SelectItem key={model} value={model}>
-                            {model}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <DialogClose asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="hover:text-destructive"
+            <DialogContent
+              showCloseButton={false}
+              className="top-[calc(var(--header-height)+var(--spacing,0.25rem)*2)] left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md border border-primary shadow-lg shadow-primary/30 hover:shadow-primary/50"
+              // ダイアログ外クリックで閉じないようにする
+              onInteractOutside={(e) => e.preventDefault()}
+              // ダイアログ外クリックで閉じないようにする
+              onPointerDownOutside={(e) => e.preventDefault()}
+              // ESC キーで閉じないようにする
+              onEscapeKeyDown={(e) => e.preventDefault()}
+            >
+              <DialogHeader>
+                <DialogTitle className="flex items-center justify-between">
+                  <div className="flex items-center justify-start text-lg font-semibold gap-1">
+                    <BotIcon />
+                    <span>AIチャット</span>
+                  </div>
+                  <div className="flex items-center justify-end  gap-1">
+                    <Select
+                      onValueChange={(value) =>
+                        setSelectedModel(modelSchema.parse(value))
+                      }
+                      value={selectedModel}
                     >
-                      <XIcon />
-                    </Button>
-                  </DialogClose>
-                </div>
-              </DialogTitle>
-            </DialogHeader>
-            <Chat model={selectedModel} />
-          </DialogContent>
-        </Dialog>
+                      <SelectTrigger>
+                        <SelectValue placeholder="モデル選択" />
+                      </SelectTrigger>
+                      <SelectContent position="popper">
+                        <SelectGroup>
+                          {MODELS.map((model) => (
+                            <SelectItem key={model} value={model}>
+                              {model}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                    <DialogClose asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="hover:text-destructive"
+                      >
+                        <XIcon />
+                      </Button>
+                    </DialogClose>
+                  </div>
+                </DialogTitle>
+              </DialogHeader>
+              <Chat />
+            </DialogContent>
+          </Dialog>
+        </ChatSessionProvider>
       </SidebarMenuItem>
     </SidebarMenu>
   )


### PR DESCRIPTION
## 概要

- AIチャットのダイアログを閉じても、入力/メッセージ/接続状態がリセットされないようにする
- AGENTS.md を追加し、Prettier 対象外に設定する

## 変更内容

- src/features/chat/components/chat-session-provider.tsx を追加し、useChat/MCP起動/IPC接続/Tools をProvider側で管理
- src/features/chat/components/chat.tsx を useChatSession() 参照に切り替え（model props 廃止）
- src/features/chat/components/open-chat.tsx で <ChatSessionProvider model={selectedModel}> を Dialog の外側に配置し、close後も状態を維持
- .prettierignore に AGENTS.md を追加（フォーマット対象から除外）
- AGENTS.md を追加（開発コマンド/規約の運用メモ）

## 影響範囲

- 影響あり: AIチャットUI（src/features/chat/components/chat.tsx, src/features/chat/components/open-chat.tsx）
- 影響なし（差分から判断できる範囲）: その他機能全般
- 注意: チャットセッションが「閉じても残る」挙動に変わる（期待仕様か要確認）

## 動作確認

- [x] pnpm test が成功する
- [x] pnpm dev で起動できる
- [x] pnpm build でビルドして exe を起動できる

## レビュー観点

- ダイアログを閉じて再度開いたときに、メッセージ/入力/ロード状態が意図通り保持されるか
- モデル切り替え時の挙動（ChatSessionProvider model がセッションに反映されるタイミング/期待値）
- MCPサーバ起動処理がProvider内 useEffect に移動したことで、起動回数やタイミングが問題ないか
- useChat の connection/tools を useMemo([]) で固定したことが意図通りか（再接続要件がないか）

## 関連リンク

- なし