### PR TITLE
chore: lint/format設定を見直してコード全体を整形

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,16 +3,44 @@
   "semi": false,
   "singleQuote": true,
   "trailingComma": "all",
-  "printWidth": 80,
-  "sortPackageJson": false,
+  "sortImports": {
+    "customGroups": [
+      {
+        "groupName": "react",
+        "elementNamePattern": ["react", "react-**"],
+        "selector": "external"
+      },
+      {
+        "groupName": "electron",
+        "elementNamePattern": ["electron"],
+        "selector": "external"
+      },
+      {
+        "groupName": "vite",
+        "elementNamePattern": ["vite", "vitest"],
+        "selector": "external"
+      }
+    ],
+    "groups": [
+      "builtin",
+      ["react", "electron"],
+      ["vite"],
+      { "newlinesBetween": false },
+      "external",
+      ["internal", "subpath"],
+      ["parent", "sibling", "index"],
+      "style",
+      "unknown"
+    ],
+    "internalPattern": ["~/", "@/", "#/"]
+  },
   "ignorePatterns": [
     "package-lock.json",
     "pnpm-lock.yaml",
-    "yarn.lock",
     ".cta.json",
+    "routeTree.gen.ts",
     "components.json",
     "index.html",
-    "package.json",
     "README.md",
     "tsconfig.json",
     "src/features/ui-demo/**",
@@ -21,6 +49,7 @@
     "src/lib/utils.ts",
     "src/styles/**",
     "src/styles.css",
-    "AGENTS.md"
+    "AGENTS.md",
+    ".*/**"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "unicorn", "oxc"],
-  "jsPlugins": ["eslint-plugin-use-no-memo"],
+  "plugins": ["typescript", "unicorn", "oxc", "import"],
   "categories": {
     "correctness": "error"
   },
@@ -14,7 +13,6 @@
     "src/components/ui/**",
     "src/lib/utils.ts",
     "src/features/ui-demo/**",
-    "electron/**",
     "**/.nx/**",
     "**/.svelte-kit/**",
     "**/build/**",
@@ -24,9 +22,27 @@
     "**/vite.config.*.timestamp-*.*"
   ],
   "rules": {
-    "use-no-memo/react-hook-form": "error",
-    "use-no-memo/tanstack-table": "error",
-    "react/rules-of-hooks": "error",
-    "react/exhaustive-deps": "warn"
-  }
+    "import/no-duplicates": "error",
+    "typescript/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "fixStyle": "separate-type-imports"
+      }
+    ],
+    "import/consistent-type-specifier-style": ["error", "prefer-top-level"]
+  },
+  "overrides": [
+    {
+      "files": ["src/**/*.{ts,tsx}"],
+      "plugins": ["react", "typescript", "unicorn", "oxc", "import"],
+      "jsPlugins": ["eslint-plugin-use-no-memo"],
+      "rules": {
+        "use-no-memo/react-hook-form": "error",
+        "use-no-memo/tanstack-table": "error",
+        "react/rules-of-hooks": "error",
+        "react/exhaustive-deps": "warn"
+      }
+    }
+  ]
 }

--- a/electron/main/api/aiChat.ts
+++ b/electron/main/api/aiChat.ts
@@ -1,13 +1,6 @@
 import type { WebContents } from 'electron'
 
 import type { ModelMessage, ServerTool, StreamChunk } from '@tanstack/ai'
-import type {
-  AddListener,
-  ApiInterface,
-  WithWebContents,
-  WithWebContentsApi,
-} from '#/shared/lib/ipc'
-import { createResponseChannel } from '#/shared/lib/ipc'
 
 import { chat } from '#/main/features/chat/chat'
 import {
@@ -15,7 +8,13 @@ import {
   switchThemeDarkTool,
   switchThemeLightTool,
 } from '#/main/features/chat/tools/tools'
-
+import type {
+  AddListener,
+  ApiInterface,
+  WithWebContents,
+  WithWebContentsApi,
+} from '#/shared/lib/ipc'
+import { createResponseChannel } from '#/shared/lib/ipc'
 import { clockToolDef } from '@/features/chat/api/tools/definitions'
 
 // -----------------------------------------------------------------------------
@@ -57,12 +56,9 @@ export type AiChatApi = ApiInterface<{
 // 実装
 
 const createChat =
-  (
-    getContext: (wc: WebContents) => AiChatContext,
-  ): WithWebContents<AiChatApi['chat']> =>
+  (getContext: (wc: WebContents) => AiChatContext): WithWebContents<AiChatApi['chat']> =>
   async (request, webContents) => {
-    const { getToolsByMcp, getSearchProjectDetailDbPath } =
-      getContext(webContents)
+    const { getToolsByMcp, getSearchProjectDetailDbPath } = getContext(webContents)
     const { messages, data, id } = request
     const { sendChunk, sendDone, sendError } = createSendFn(webContents, id)
 
@@ -110,10 +106,7 @@ function createSendFn(webContents: WebContents, id: string) {
     try {
       webContents.send(channel, response)
     } catch (error) {
-      console.error(
-        `${new Date().toISOString()} Error sending AiChatApi chunk:`,
-        error,
-      )
+      console.error(`${new Date().toISOString()} Error sending AiChatApi chunk:`, error)
     }
   }
   const sendChunk = (chunk: StreamChunk) => {

--- a/electron/main/api/auth.ts
+++ b/electron/main/api/auth.ts
@@ -1,6 +1,7 @@
 import type { WebContents } from 'electron'
 
 import type { ApiInterface, WithWebContentsApi } from '#/shared/lib/ipc'
+
 import type { AuthRuntime } from '../features/auth/authRuntime'
 import type { AuthStatus } from '../features/auth/authService'
 

--- a/electron/main/api/fs.ts
+++ b/electron/main/api/fs.ts
@@ -1,18 +1,15 @@
 import fs from 'node:fs/promises'
 import nodePath from 'node:path'
-import { dialog, shell } from 'electron'
 
+import { dialog, shell } from 'electron'
 import type {
   OpenDialogOptions,
   OpenDialogReturnValue,
   SaveDialogOptions,
   SaveDialogReturnValue,
 } from 'electron'
-import type {
-  ApiInterface,
-  WithWebContents,
-  WithWebContentsApi,
-} from '#/shared/lib/ipc'
+
+import type { ApiInterface, WithWebContents, WithWebContentsApi } from '#/shared/lib/ipc'
 
 // -----------------------------------------------------------------------------
 // 型定義
@@ -82,10 +79,7 @@ export type FileSystemApi = ApiInterface<{
    * @param options.path 書き込むファイルのパス
    * @param options.data 書き込むバイナリデータ
    */
-  writeFileAsArrayBuffer: (options: {
-    path: string
-    data: ArrayBuffer
-  }) => Promise<void>
+  writeFileAsArrayBuffer: (options: { path: string; data: ArrayBuffer }) => Promise<void>
   /**
    * ファイルを開くダイアログを表示します。
    * @param options オプション https://www.electronjs.org/ja/docs/latest/api/dialog#dialogshowopendialogwindow-options
@@ -130,17 +124,15 @@ export type FileSystemRendererApi = Readonly<{
 const joinPath: WithWebContents<FileSystemApi['joinPath']> = async (options) =>
   nodePath.join(...options.parts)
 
-const readFileAsText: WithWebContents<FileSystemApi['readFileAsText']> = async (
-  options,
-) => {
+const readFileAsText: WithWebContents<FileSystemApi['readFileAsText']> = async (options) => {
   const { path } = options
   const text = await fs.readFile(path, 'utf-8')
   return text
 }
 
-const readFileAsArrayBuffer: WithWebContents<
-  FileSystemApi['readFileAsArrayBuffer']
-> = async (options) => {
+const readFileAsArrayBuffer: WithWebContents<FileSystemApi['readFileAsArrayBuffer']> = async (
+  options,
+) => {
   const { path } = options
   const buffer = await fs.readFile(path)
 
@@ -158,36 +150,28 @@ const readFileAsArrayBuffer: WithWebContents<
   return arrayBuffer
 }
 
-const writeFileAsText: WithWebContents<
-  FileSystemApi['writeFileAsText']
-> = async (options) => {
+const writeFileAsText: WithWebContents<FileSystemApi['writeFileAsText']> = async (options) => {
   const { path, data } = options
   await fs.writeFile(path, data, 'utf-8')
 }
 
-const writeFileAsArrayBuffer: WithWebContents<
-  FileSystemApi['writeFileAsArrayBuffer']
-> = async (options) => {
+const writeFileAsArrayBuffer: WithWebContents<FileSystemApi['writeFileAsArrayBuffer']> = async (
+  options,
+) => {
   const { path, data } = options
   const buffer = Buffer.from(data)
   await fs.writeFile(path, buffer)
 }
 
-const showOpenDialog: WithWebContents<FileSystemApi['showOpenDialog']> = async (
-  options,
-) => {
+const showOpenDialog: WithWebContents<FileSystemApi['showOpenDialog']> = async (options) => {
   return await dialog.showOpenDialog(options)
 }
 
-const showSaveDialog: WithWebContents<FileSystemApi['showSaveDialog']> = async (
-  options,
-) => {
+const showSaveDialog: WithWebContents<FileSystemApi['showSaveDialog']> = async (options) => {
   return await dialog.showSaveDialog(options)
 }
 
-const readDirectory: WithWebContents<FileSystemApi['readDirectory']> = async (
-  options,
-) => {
+const readDirectory: WithWebContents<FileSystemApi['readDirectory']> = async (options) => {
   const { path } = options
   const entries = await fs.readdir(path, { withFileTypes: true })
   return entries.map((entry) => ({
@@ -197,16 +181,14 @@ const readDirectory: WithWebContents<FileSystemApi['readDirectory']> = async (
   }))
 }
 
-const openFileByDefaultApp: WithWebContents<
-  FileSystemApi['openFileByDefaultApp']
-> = async (options) => {
+const openFileByDefaultApp: WithWebContents<FileSystemApi['openFileByDefaultApp']> = async (
+  options,
+) => {
   const { path } = options
   await shell.openPath(path)
 }
 
-const getFileDetails: WithWebContents<FileSystemApi['getFileDetails']> = async (
-  options,
-) => {
+const getFileDetails: WithWebContents<FileSystemApi['getFileDetails']> = async (options) => {
   let path: string
   if ('path' in options) {
     path = options.path

--- a/electron/main/api/kakeibo.ts
+++ b/electron/main/api/kakeibo.ts
@@ -1,6 +1,8 @@
 import type { WebContents } from 'electron'
-import type { DataBase } from '../features/db/db'
+
 import type { ApiInterface, WithWebContentsApi } from '#/shared/lib/ipc'
+
+import type { DataBase } from '../features/db/db'
 
 // -----------------------------------------------------------------------------
 // 型定義
@@ -38,9 +40,7 @@ export function getKakeiboApi(
     entries: async (wc) => {
       const db = getContext(wc).getDb()
 
-      const entries = db.query(
-        'SELECT * FROM expense_view ORDER BY spent_at DESC;',
-      )
+      const entries = db.query('SELECT * FROM expense_view ORDER BY spent_at DESC;')
 
       return entries as KakeiboEntry[]
     },

--- a/electron/main/api/mcp.ts
+++ b/electron/main/api/mcp.ts
@@ -1,12 +1,9 @@
-import { startServer as startMcpServer } from '../features/mcp'
-
 import type { WebContents } from 'electron'
+
+import type { ApiInterface, WithWebContents, WithWebContentsApi } from '#/shared/lib/ipc'
+
+import { startServer as startMcpServer } from '../features/mcp'
 import type { McpServer } from '../features/mcp'
-import type {
-  ApiInterface,
-  WithWebContents,
-  WithWebContentsApi,
-} from '#/shared/lib/ipc'
 
 // -----------------------------------------------------------------------------
 // 型定義

--- a/electron/main/api/theme.ts
+++ b/electron/main/api/theme.ts
@@ -1,6 +1,6 @@
 import { nativeTheme, systemPreferences } from 'electron'
-
 import type { Event, WebContents, TitleBarOverlayOptions } from 'electron'
+
 import type {
   ApiInterface,
   AddListener,
@@ -56,15 +56,11 @@ const createSetTheme = (
   }
 }
 
-const getAccentColor: WithWebContents<
-  ThemeApi['getAccentColor']
-> = async () => {
+const getAccentColor: WithWebContents<ThemeApi['getAccentColor']> = async () => {
   return systemPreferences.getAccentColor()
 }
 
-const onAccentColorChanged: WithWebContents<
-  ThemeApi['on']['accentColorChanged']
-> = (listener) => {
+const onAccentColorChanged: WithWebContents<ThemeApi['on']['accentColorChanged']> = (listener) => {
   const listenerWrapper = (_: Event, newColor: string) => {
     return listener(newColor)
   }

--- a/electron/main/api/web.ts
+++ b/electron/main/api/web.ts
@@ -1,9 +1,6 @@
 import type { Event, Result } from 'electron'
-import type {
-  ApiInterface,
-  AddListener,
-  WithWebContentsApi,
-} from '#/shared/lib/ipc'
+
+import type { ApiInterface, AddListener, WithWebContentsApi } from '#/shared/lib/ipc'
 
 // -----------------------------------------------------------------------------
 // 型定義
@@ -32,8 +29,7 @@ export type WebApi = ApiInterface<{
 export function getWebApi(): WithWebContentsApi<WebApi> {
   return {
     findInPage: async ({ text }, webContents) => webContents.findInPage(text),
-    stopFindInPage: async ({ action }, webContents) =>
-      webContents.stopFindInPage(action),
+    stopFindInPage: async ({ action }, webContents) => webContents.stopFindInPage(action),
     on: {
       blur: (listener, webContents) => {
         const listenerWrapper = () => listener()

--- a/electron/main/app/startApp.ts
+++ b/electron/main/app/startApp.ts
@@ -110,8 +110,7 @@ export async function startApp<TAppContext>(options: {
   openMainWindow({ appRuntime, appContext })
 }
 
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms))
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
 /**
  * 破棄処理をタイムアウト付きで実行する
@@ -160,10 +159,7 @@ async function disposeAndExit(
     // タイムアウト付きで破棄処理を実行
     await runDisposeWithTimeout(disposers, timeoutMs)
   } catch (err) {
-    console.error(
-      '[app:before-quit] dispose did not finish; force exiting:',
-      err,
-    )
+    console.error('[app:before-quit] dispose did not finish; force exiting:', err)
   } finally {
     // app.quit() だと before-quit が再度走る可能性があるため exit を使う
     app.exit(0)

--- a/electron/main/features/auth/authDb.ts
+++ b/electron/main/features/auth/authDb.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+
 import { app } from 'electron'
 
 import { DataBase } from '../db/db'

--- a/electron/main/features/auth/authRuntime.ts
+++ b/electron/main/features/auth/authRuntime.ts
@@ -1,6 +1,5 @@
 import { createAuthDb, ensureAuthDb } from './authDb'
 import { getAuthStatus, login, logout } from './authService'
-
 import type { AuthStatus } from './authService'
 
 export type AuthRuntime = {

--- a/electron/main/features/auth/authService.ts
+++ b/electron/main/features/auth/authService.ts
@@ -107,9 +107,7 @@ function createCurrentSession(db: DataBase, userId: number) {
   )
 }
 
-function readCurrentSessionUser(
-  db: DataBase,
-): DbAuthSessionWithUser | undefined {
+function readCurrentSessionUser(db: DataBase): DbAuthSessionWithUser | undefined {
   return db.get<DbAuthSessionWithUser>(
     [
       'SELECT u.username as username, s.expires_at as expires_at',
@@ -135,10 +133,9 @@ export function getAuthStatus(db: DataBase): AuthStatus {
     return { isAuthenticated: false, user: null }
   }
 
-  db.run(
-    'UPDATE auth_sessions SET last_used_at = ? WHERE is_current = 1 AND revoked_at IS NULL',
-    [nowIso()],
-  )
+  db.run('UPDATE auth_sessions SET last_used_at = ? WHERE is_current = 1 AND revoked_at IS NULL', [
+    nowIso(),
+  ])
 
   return {
     isAuthenticated: true,
@@ -146,11 +143,7 @@ export function getAuthStatus(db: DataBase): AuthStatus {
   }
 }
 
-export function login(
-  db: DataBase,
-  username: string,
-  password: string,
-): AuthStatus {
+export function login(db: DataBase, username: string, password: string): AuthStatus {
   const normalized = username.trim()
   if (!normalized) {
     throw new Error('username is required')

--- a/electron/main/features/chat/chat.ts
+++ b/electron/main/features/chat/chat.ts
@@ -1,10 +1,9 @@
 import { chat as tanstackChat } from '@tanstack/ai'
-
 import type { ModelMessage, StreamChunk, TextOptions } from '@tanstack/ai'
 
-import { isOllamaModelMessage, type OllamaModelMessage } from './ollama/ollama'
 import { adapters } from './ollama/adapters'
 import { modelSchema } from './ollama/models'
+import { isOllamaModelMessage, type OllamaModelMessage } from './ollama/ollama'
 
 export type ChatRequest = {
   messages: ModelMessage[]
@@ -30,10 +29,7 @@ export async function chat(options: {
   } = options
 
   try {
-    console.log(
-      `${new Date().toISOString()} Starting chat with messages:`,
-      messages,
-    )
+    console.log(`${new Date().toISOString()} Starting chat with messages:`, messages)
     console.log(`${new Date().toISOString()} Chat request data:`, data)
 
     const model = modelSchema.parse((data as any)?.model || 'gpt-oss:20b-cloud')
@@ -89,10 +85,7 @@ export async function chat(options: {
       onDone()
     })().catch((err) => {
       // try-catch では捕捉できないエラーをキャッチ
-      console.error(
-        `${new Date().toISOString()} Error in AiChatApi chat stream:`,
-        err,
-      )
+      console.error(`${new Date().toISOString()} Error in AiChatApi chat stream:`, err)
       // エラーを通知
       onError(err)
     })

--- a/electron/main/features/chat/chat.ts
+++ b/electron/main/features/chat/chat.ts
@@ -3,7 +3,8 @@ import type { ModelMessage, StreamChunk, TextOptions } from '@tanstack/ai'
 
 import { adapters } from './ollama/adapters'
 import { modelSchema } from './ollama/models'
-import { isOllamaModelMessage, type OllamaModelMessage } from './ollama/ollama'
+import { isOllamaModelMessage } from './ollama/ollama'
+import type { OllamaModelMessage } from './ollama/ollama'
 
 export type ChatRequest = {
   messages: ModelMessage[]

--- a/electron/main/features/chat/ollama/adapters.ts
+++ b/electron/main/features/chat/ollama/adapters.ts
@@ -1,10 +1,8 @@
 import { createOllamaChat } from '@tanstack/ai-ollama'
+
 import type { Model } from './models'
 
-export const adapters: Record<
-  Model,
-  () => ReturnType<typeof createOllamaChat>
-> = {
+export const adapters: Record<Model, () => ReturnType<typeof createOllamaChat>> = {
   'gpt-oss:20b-cloud': () => createOllamaChat('gpt-oss:20b-cloud'),
   'gpt-oss:120b-cloud': () => createOllamaChat('gpt-oss:120b-cloud'),
   'qwen3-vl:235b-cloud': () => createOllamaChat('qwen3-vl:235b-cloud'),

--- a/electron/main/features/chat/ollama/models.ts
+++ b/electron/main/features/chat/ollama/models.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod'
 
-export const MODELS = [
-  'gpt-oss:20b-cloud',
-  'gpt-oss:120b-cloud',
-  'qwen3-vl:235b-cloud',
-] as const
+export const MODELS = ['gpt-oss:20b-cloud', 'gpt-oss:120b-cloud', 'qwen3-vl:235b-cloud'] as const
 
 export const modelSchema = z.enum(MODELS)
 

--- a/electron/main/features/chat/ollama/ollama.ts
+++ b/electron/main/features/chat/ollama/ollama.ts
@@ -1,8 +1,4 @@
-import type {
-  ConstrainedModelMessage,
-  InputModalitiesTypes,
-  ModelMessage,
-} from '@tanstack/ai'
+import type { ConstrainedModelMessage, InputModalitiesTypes, ModelMessage } from '@tanstack/ai'
 
 export type OllamaInputModalities = readonly ['text', 'image']
 export type OllamaModelMessage = ConstrainedModelMessage<
@@ -11,9 +7,7 @@ export type OllamaModelMessage = ConstrainedModelMessage<
   }
 >
 
-export function isOllamaModelMessage(
-  message: ModelMessage,
-): message is OllamaModelMessage {
+export function isOllamaModelMessage(message: ModelMessage): message is OllamaModelMessage {
   if (typeof message.content === 'string' || message.content === null) {
     return true
   }

--- a/electron/main/features/chat/tools/tools.ts
+++ b/electron/main/features/chat/tools/tools.ts
@@ -1,6 +1,7 @@
 import { nativeTheme } from 'electron'
 
-import { retrieveRagContext, type RetrieveRagContextOptions } from '#/shared/lib/rag/retrieve'
+import { retrieveRagContext } from '#/shared/lib/rag/retrieve'
+import type { RetrieveRagContextOptions } from '#/shared/lib/rag/retrieve'
 
 import {
   switchThemeDarkToolDef,

--- a/electron/main/features/chat/tools/tools.ts
+++ b/electron/main/features/chat/tools/tools.ts
@@ -1,13 +1,12 @@
 import { nativeTheme } from 'electron'
+
+import { retrieveRagContext, type RetrieveRagContextOptions } from '#/shared/lib/rag/retrieve'
+
 import {
   switchThemeDarkToolDef,
   switchThemeLightToolDef,
   searchProjectDetailToolDef,
 } from './definitions'
-import {
-  retrieveRagContext,
-  type RetrieveRagContextOptions,
-} from '#/shared/lib/rag/retrieve'
 
 export const switchThemeDarkTool = switchThemeDarkToolDef.server(async () => {
   nativeTheme.themeSource = 'dark'
@@ -25,9 +24,7 @@ export const switchThemeLightTool = switchThemeLightToolDef.server(async () => {
   }
 })
 
-export function createSearchProjectDetailTool(
-  options: RetrieveRagContextOptions,
-) {
+export function createSearchProjectDetailTool(options: RetrieveRagContextOptions) {
   const { dbPath, docName, model, queryPrefix, topK } = options
   return searchProjectDetailToolDef.server(async ({ question }) => {
     const context = await retrieveRagContext(question, {

--- a/electron/main/features/db/db.ts
+++ b/electron/main/features/db/db.ts
@@ -14,7 +14,6 @@
  *   制約のもと、利用側からファイル名を受け取って解決します。
  */
 import BetterSqlite3 from 'better-sqlite3'
-
 import type { Database as BetterSqlite3Database, Options } from 'better-sqlite3'
 
 /**
@@ -99,9 +98,6 @@ export class DataBase {
  * 既定の場所から DB を開くファクトリ。
  * @param options better-sqlite3 のオプション（readonly 推奨）
  */
-export function createAppDataBase(
-  filePath: string,
-  options?: Options,
-): DataBase {
+export function createAppDataBase(filePath: string, options?: Options): DataBase {
   return new DataBase(filePath, options)
 }

--- a/electron/main/features/mcp/index.ts
+++ b/electron/main/features/mcp/index.ts
@@ -1,5 +1,6 @@
-import express from 'express'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import express from 'express'
+
 import { createMcpServer } from './mcpServer.js'
 
 export type McpServer = {

--- a/electron/main/features/mcp/mcpServer.ts
+++ b/electron/main/features/mcp/mcpServer.ts
@@ -1,4 +1,5 @@
 import { nativeTheme } from 'electron'
+
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 
@@ -20,9 +21,7 @@ export function createMcpServer() {
     async ({ message }) => {
       console.log(message)
       return {
-        content: [
-          { type: 'text', text: `ログに「${message}」を出力しました。` },
-        ],
+        content: [{ type: 'text', text: `ログに「${message}」を出力しました。` }],
       }
     },
   )
@@ -40,9 +39,7 @@ export function createMcpServer() {
       nativeTheme.themeSource = theme
       console.log('theme', theme)
       return {
-        content: [
-          { type: 'text', text: `テーマを「${theme}」に変更しました。` },
-        ],
+        content: [{ type: 'text', text: `テーマを「${theme}」に変更しました。` }],
       }
     },
   )

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,21 +1,25 @@
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-import { app, BrowserWindow } from 'electron'
-import type { WebContents } from 'electron'
+import { app } from 'electron'
+import type { WebContents, BrowserWindow } from 'electron'
 
 import type { ServerTool } from '@tanstack/ai'
 
 import { mcpToTanStackAiTools } from '#/shared/lib/tanstack-ai-mcp'
 
-import { startApp, type AppRuntime } from './app/startApp'
+import { startApp } from './app/startApp'
+import type { AppRuntime } from './app/startApp'
 import type { AuthRuntime } from './features/auth/authRuntime'
 import { createAuthRuntime } from './features/auth/authRuntime'
-import { createAppDataBase, type DataBase } from './features/db/db'
+import { createAppDataBase } from './features/db/db'
+import type { DataBase } from './features/db/db'
 import type { McpServer } from './features/mcp'
-import { resolveMainPaths, type MainPaths } from './infra/paths'
+import { resolveMainPaths } from './infra/paths'
+import type { MainPaths } from './infra/paths'
 import { registerCustomProtocol } from './infra/registerCustomProtocol'
-import { registerIpc, type Context } from './ipc/registerIpc'
+import { registerIpc } from './ipc/registerIpc'
+import type { Context } from './ipc/registerIpc'
 import { createWindow, recommendedSecureOptions } from './windows/createWindow'
 
 /** __dirname の代替 */

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,19 +1,22 @@
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { app, BrowserWindow } from 'electron'
 
+import { app, BrowserWindow } from 'electron'
 import type { WebContents } from 'electron'
+
 import type { ServerTool } from '@tanstack/ai'
+
+import { mcpToTanStackAiTools } from '#/shared/lib/tanstack-ai-mcp'
+
+import { startApp, type AppRuntime } from './app/startApp'
 import type { AuthRuntime } from './features/auth/authRuntime'
+import { createAuthRuntime } from './features/auth/authRuntime'
 import { createAppDataBase, type DataBase } from './features/db/db'
 import type { McpServer } from './features/mcp'
-import { registerIpc, type Context } from './ipc/registerIpc'
-import { startApp, type AppRuntime } from './app/startApp'
-import { createAuthRuntime } from './features/auth/authRuntime'
 import { resolveMainPaths, type MainPaths } from './infra/paths'
 import { registerCustomProtocol } from './infra/registerCustomProtocol'
+import { registerIpc, type Context } from './ipc/registerIpc'
 import { createWindow, recommendedSecureOptions } from './windows/createWindow'
-import { mcpToTanStackAiTools } from '#/shared/lib/tanstack-ai-mcp'
 
 /** __dirname の代替 */
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -78,13 +81,10 @@ startApp<AppContext>({
      * @param p パス
      * @returns 末尾セパレータ付きのパス
      */
-    const ensureTrailingSeparator = (p: string) =>
-      p.endsWith(path.sep) ? p : p + path.sep
+    const ensureTrailingSeparator = (p: string) => (p.endsWith(path.sep) ? p : p + path.sep)
 
     const rendererRootUrl = appContext.paths.rendererDist
-      ? pathToFileURL(
-          ensureTrailingSeparator(appContext.paths.rendererDist),
-        ).toString()
+      ? pathToFileURL(ensureTrailingSeparator(appContext.paths.rendererDist)).toString()
       : null
 
     createWindow(
@@ -106,9 +106,7 @@ startApp<AppContext>({
           titleBarStyle: 'hidden',
           // macOS 以外は titleBarOverlay を有効にしてタイトルバーとコンテンツを重ねる
           // https://www.electronjs.org/ja/docs/latest/tutorial/custom-title-bar#%E3%83%8D%E3%82%A4%E3%83%86%E3%82%A3%E3%83%96%E3%81%AE%E3%82%A6%E3%82%A4%E3%83%B3%E3%83%89%E3%82%A6%E3%82%B3%E3%83%B3%E3%83%88%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%99%E3%82%8B-windows-linux
-          ...(process.platform !== 'darwin'
-            ? { titleBarOverlay: createTitleBarOverlay() }
-            : {}),
+          ...(process.platform !== 'darwin' ? { titleBarOverlay: createTitleBarOverlay() } : {}),
           webPreferences: {
             ...recommendedSecureOptions,
             preload: appContext.paths.preloadPath,
@@ -211,13 +209,10 @@ function createWindowContext(
       getDb: () => {
         if (!appContext.db) {
           try {
-            const db = createAppDataBase(
-              path.join(appContext.paths.dataPath, 'kakeibo.db'),
-              {
-                readonly: false,
-                fileMustExist: false,
-              },
-            )
+            const db = createAppDataBase(path.join(appContext.paths.dataPath, 'kakeibo.db'), {
+              readonly: false,
+              fileMustExist: false,
+            })
             appContext.db = db
             console.log(`[DB] Database opened successfully at kakeibo.db`)
           } catch (error) {

--- a/electron/main/infra/paths.ts
+++ b/electron/main/infra/paths.ts
@@ -147,9 +147,7 @@ export function resolveMainPaths(args: {
     : // DEV時には使用しない
       ''
 
-  const dataPath = isProd
-    ? path.join(process.resourcesPath, 'data')
-    : path.join(appRoot, 'data')
+  const dataPath = isProd ? path.join(process.resourcesPath, 'data') : path.join(appRoot, 'data')
 
   return {
     appRoot,

--- a/electron/main/infra/registerCustomProtocol.ts
+++ b/electron/main/infra/registerCustomProtocol.ts
@@ -1,6 +1,7 @@
-import { protocol } from 'electron'
-import path from 'node:path'
 import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { protocol } from 'electron'
 
 export function registerCustomProtocol() {
   protocol.handle('app', async (request) => {

--- a/electron/main/ipc/electronApi.ts
+++ b/electron/main/ipc/electronApi.ts
@@ -1,17 +1,13 @@
 import { webUtils } from 'electron'
-import { createElectronApi } from '#/shared/lib/ipc/browser'
 
-import type {
-  FileSystemApi,
-  FileSystemRendererApi,
-  FS_API_KEY,
-} from '#/main/api/fs'
+import type { AiChatApi, AI_CHAT_API_KEY } from '#/main/api/aiChat'
+import type { AuthApi, AUTH_API_KEY } from '#/main/api/auth'
+import type { FileSystemApi, FileSystemRendererApi, FS_API_KEY } from '#/main/api/fs'
+import type { KakeiboApi, Kakeibo_API_KEY } from '#/main/api/kakeibo'
+import type { McpApi, MCP_API_KEY } from '#/main/api/mcp'
 import type { ThemeApi, THEME_API_KEY } from '#/main/api/theme'
 import type { WebApi, WEB_API_KEY } from '#/main/api/web'
-import type { McpApi, MCP_API_KEY } from '#/main/api/mcp'
-import type { AiChatApi, AI_CHAT_API_KEY } from '#/main/api/aiChat'
-import type { KakeiboApi, Kakeibo_API_KEY } from '#/main/api/kakeibo'
-import type { AuthApi, AUTH_API_KEY } from '#/main/api/auth'
+import { createElectronApi } from '#/shared/lib/ipc/browser'
 
 type ElectronRendererApi = {
   [FS_API_KEY]: FileSystemRendererApi
@@ -27,14 +23,10 @@ export type ElectronMainApi = {
   [AUTH_API_KEY]: AuthApi
 }
 
-const getPathForFile: FileSystemRendererApi['getPathForFile'] = async (
-  options,
-) => webUtils.getPathForFile(options.file)
+const getPathForFile: FileSystemRendererApi['getPathForFile'] = async (options) =>
+  webUtils.getPathForFile(options.file)
 
-export const electronApi = createElectronApi<
-  ElectronMainApi,
-  ElectronRendererApi
->(
+export const electronApi = createElectronApi<ElectronMainApi, ElectronRendererApi>(
   ({ defineHelper, useChannelAsInvoke, useChannelAsEvent }) =>
     /**
      * defineHelper の使用は任意ですが、以下の利点があります。

--- a/electron/main/ipc/registerIpc.ts
+++ b/electron/main/ipc/registerIpc.ts
@@ -1,18 +1,19 @@
-import { createRegisterIpc } from '#/shared/lib/ipc/main'
-import { getFileSystemApi } from '#/main/api/fs'
-import { THEME_API_KEY, getThemeApi } from '#/main/api/theme'
-import { getWebApi } from '#/main/api/web'
-import { MCP_API_KEY, getMcpApi } from '#/main/api/mcp'
-import { AI_CHAT_API_KEY, getAiChatApi } from '#/main/api/aiChat'
-import { Kakeibo_API_KEY, getKakeiboApi } from '#/main/api/kakeibo'
-import { AUTH_API_KEY, getAuthApi } from '#/main/api/auth'
-
 import type { WebContents } from 'electron'
-import type { ThemeContext } from '#/main/api/theme'
-import type { McpApiContext } from '#/main/api/mcp'
+
+import { AI_CHAT_API_KEY, getAiChatApi } from '#/main/api/aiChat'
 import type { AiChatContext } from '#/main/api/aiChat'
-import type { KakeiboContext } from '#/main/api/kakeibo'
+import { AUTH_API_KEY, getAuthApi } from '#/main/api/auth'
 import type { AuthContext } from '#/main/api/auth'
+import { getFileSystemApi } from '#/main/api/fs'
+import { Kakeibo_API_KEY, getKakeiboApi } from '#/main/api/kakeibo'
+import type { KakeiboContext } from '#/main/api/kakeibo'
+import { MCP_API_KEY, getMcpApi } from '#/main/api/mcp'
+import type { McpApiContext } from '#/main/api/mcp'
+import { THEME_API_KEY, getThemeApi } from '#/main/api/theme'
+import type { ThemeContext } from '#/main/api/theme'
+import { getWebApi } from '#/main/api/web'
+import { createRegisterIpc } from '#/shared/lib/ipc/main'
+
 import type { ElectronMainApi } from './electronApi'
 
 export type Context = {
@@ -26,17 +27,11 @@ export type Context = {
 export const registerIpc = createRegisterIpc<ElectronMainApi, Context>(
   ({ getContext, defineHelper }) => {
     const fs = getFileSystemApi()
-    const theme = getThemeApi(
-      (wc: WebContents) => getContext(wc)[THEME_API_KEY],
-    )
+    const theme = getThemeApi((wc: WebContents) => getContext(wc)[THEME_API_KEY])
     const web = getWebApi()
     const mcp = getMcpApi((wc: WebContents) => getContext(wc)[MCP_API_KEY])
-    const aiChat = getAiChatApi(
-      (wc: WebContents) => getContext(wc)[AI_CHAT_API_KEY],
-    )
-    const kakeibo = getKakeiboApi(
-      (wc: WebContents) => getContext(wc)[Kakeibo_API_KEY],
-    )
+    const aiChat = getAiChatApi((wc: WebContents) => getContext(wc)[AI_CHAT_API_KEY])
+    const kakeibo = getKakeiboApi((wc: WebContents) => getContext(wc)[Kakeibo_API_KEY])
     const auth = getAuthApi((wc: WebContents) => getContext(wc)[AUTH_API_KEY])
 
     return defineHelper({

--- a/electron/main/windows/createWindow.ts
+++ b/electron/main/windows/createWindow.ts
@@ -1,8 +1,5 @@
-import {
-  BrowserWindow,
-  shell,
-  type BrowserWindowConstructorOptions,
-} from 'electron'
+import { BrowserWindow, shell, type BrowserWindowConstructorOptions } from 'electron'
+
 import { createContextMenu } from './createContextMenu'
 
 type NavigationPolicy = {
@@ -51,8 +48,7 @@ export async function createWindow(
     onClosed?: () => void
   } = {},
 ) {
-  const { browserWindowOptions, navigation, onCreated, onClose, onClosed } =
-    options
+  const { browserWindowOptions, navigation, onCreated, onClose, onClosed } = options
 
   const isAllowedNavigation = createIsAllowedNavigation(
     navigation ?? {
@@ -72,11 +68,9 @@ export async function createWindow(
     webPreferences: {
       ...browserWindowOptions?.webPreferences,
       // セキュリティ強化のために contextIsolation が省略された場合には明示的に有効化
-      contextIsolation:
-        browserWindowOptions?.webPreferences?.contextIsolation ?? true,
+      contextIsolation: browserWindowOptions?.webPreferences?.contextIsolation ?? true,
       // セキュリティ強化のために nodeIntegration が省略された場合には明示的に無効化
-      nodeIntegration:
-        browserWindowOptions?.webPreferences?.nodeIntegration ?? false,
+      nodeIntegration: browserWindowOptions?.webPreferences?.nodeIntegration ?? false,
     },
   })
 
@@ -193,11 +187,7 @@ export async function createWindow(
 const isAllowedExternalUrl = (urlString: string) => {
   try {
     const url = new URL(urlString)
-    return (
-      url.protocol === 'https:' ||
-      url.protocol === 'http:' ||
-      url.protocol === 'mailto:'
-    )
+    return url.protocol === 'https:' || url.protocol === 'http:' || url.protocol === 'mailto:'
   } catch {
     return false
   }

--- a/electron/main/windows/createWindow.ts
+++ b/electron/main/windows/createWindow.ts
@@ -1,4 +1,5 @@
-import { BrowserWindow, shell, type BrowserWindowConstructorOptions } from 'electron'
+import { BrowserWindow, shell } from 'electron'
+import type { BrowserWindowConstructorOptions } from 'electron'
 
 import { createContextMenu } from './createContextMenu'
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge } from 'electron'
+
 import { electronApi } from '#/main/ipc/electronApi'
 
 contextBridge.exposeInMainWorld('api', electronApi)

--- a/electron/shared/lib/ipc/browser/createElectronApi.ts
+++ b/electron/shared/lib/ipc/browser/createElectronApi.ts
@@ -1,13 +1,8 @@
 import { ipcRenderer } from 'electron'
-import { deepMergeRecord } from './deepMerge'
-import { createResponseChannel } from '../shared/createResponseChannel'
 
-import type {
-  Api,
-  RecursiveMethodKeys,
-  ExtractMethod,
-  Listener,
-} from '../shared/types'
+import { createResponseChannel } from '../shared/createResponseChannel'
+import type { Api, RecursiveMethodKeys, ExtractMethod, Listener } from '../shared/types'
+import { deepMergeRecord } from './deepMerge'
 
 type UseChannel<TElectronApi extends Api> = {
   <TChannel extends RecursiveMethodKeys<TElectronApi>>(
@@ -34,9 +29,7 @@ const useChannelAsInvoke = <TElectronMainApi extends Api>(
 
 const useChannelAsEvent =
   (map: Map<string, () => void>) =>
-  <TElectronMainApi extends Api>(
-    channel: RecursiveMethodKeys<TElectronMainApi>,
-  ) => {
+  <TElectronMainApi extends Api>(channel: RecursiveMethodKeys<TElectronMainApi>) => {
     const responseChannel = createResponseChannel(channel)
     const addListener = (listener: Listener<any>) => {
       if (map.has(channel)) {
@@ -45,10 +38,7 @@ const useChannelAsEvent =
       }
 
       // イベント取りこぼしを防ぐため、先にリスナーを登録する
-      const listenerWrapper = (
-        _: Electron.IpcRendererEvent,
-        ...args: any[]
-      ) => {
+      const listenerWrapper = (_: Electron.IpcRendererEvent, ...args: any[]) => {
         // 規約として args[1] 以降は無視して、args[0] のみを渡す
         listener(args[0])
       }
@@ -73,14 +63,10 @@ const useChannelAsEvent =
           .invoke(channel, false)
           .then((success) => {
             if (!success) {
-              console.warn(
-                `Listener for ${channel} was already removed in main process.`,
-              )
+              console.warn(`Listener for ${channel} was already removed in main process.`)
             }
           })
-          .catch((error) =>
-            console.error(`Failed to remove listener for ${channel}:`, error),
-          )
+          .catch((error) => console.error(`Failed to remove listener for ${channel}:`, error))
       }
 
       map.set(channel, removeListener)
@@ -90,9 +76,7 @@ const useChannelAsEvent =
         .invoke(channel, true)
         .then((success) => {
           if (!success) {
-            console.warn(
-              `Listener for ${channel} was already registered in main process.`,
-            )
+            console.warn(`Listener for ${channel} was already registered in main process.`)
           }
         })
         .catch((error) => {

--- a/electron/shared/lib/ipc/browser/deepMerge.test.ts
+++ b/electron/shared/lib/ipc/browser/deepMerge.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+
 import { deepMergeRecord } from './deepMerge'
 
 describe('deepMerge', () => {

--- a/electron/shared/lib/ipc/index.ts
+++ b/electron/shared/lib/ipc/index.ts
@@ -1,7 +1,2 @@
 export * from './shared/createResponseChannel'
-export type {
-  ApiInterface,
-  WithWebContents,
-  WithWebContentsApi,
-  AddListener,
-} from './shared/types'
+export type { ApiInterface, WithWebContents, WithWebContentsApi, AddListener } from './shared/types'

--- a/electron/shared/lib/ipc/main/createRegisterIpc.ts
+++ b/electron/shared/lib/ipc/main/createRegisterIpc.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron'
-import { createResponseChannel } from '../shared/createResponseChannel'
-
 import type { WebContents } from 'electron'
+
+import { createResponseChannel } from '../shared/createResponseChannel'
 import type {
   Api,
   IpcRegistrationMap,
@@ -11,10 +11,7 @@ import type {
   ExtractAddListener,
 } from '../shared/types'
 
-type CreateRegistrationMap<
-  TElectronMainApi extends Api,
-  TContext = any,
-> = (helpers: {
+type CreateRegistrationMap<TElectronMainApi extends Api, TContext = any> = (helpers: {
   getContext: (webContents: WebContents) => TContext
   defineHelper: <T extends IpcRegistrationMap<TElectronMainApi>>(map: T) => T
 }) => IpcRegistrationMap<TElectronMainApi>
@@ -38,10 +35,7 @@ const createRegisterInvoke =
       `${new Date().toISOString()} INFO: IPC Invoke Handler registered. Channel: ${channel}`,
     )
 
-    const listener = async (
-      event: Electron.IpcMainInvokeEvent,
-      ...args: any[]
-    ) => {
+    const listener = async (event: Electron.IpcMainInvokeEvent, ...args: any[]) => {
       try {
         // イベント送信元の WebContents を取得
         const webContents = event.sender
@@ -140,9 +134,7 @@ const createRegisterEvent = <TElectronMainApi extends Api>(
      * addListener: ExtractAddListener<TElectronMainApi, TChannel>
      * ```
      */
-    addListener: WithWebContents<
-      ExtractAddListener<TElectronMainApi, TChannel>
-    >,
+    addListener: WithWebContents<ExtractAddListener<TElectronMainApi, TChannel>>,
   ) => {
     /**
      * イベントリスナー登録/解除ハンドラ
@@ -150,10 +142,7 @@ const createRegisterEvent = <TElectronMainApi extends Api>(
      * @param register 登録する場合は true、解除する場合は false
      * @returns 登録/解除が成功した場合は true、すでに登録/解除されていた場合は false
      */
-    const registrationListener = (
-      event: Electron.IpcMainInvokeEvent,
-      register: boolean,
-    ) => {
+    const registrationListener = (event: Electron.IpcMainInvokeEvent, register: boolean) => {
       // イベント送信元の WebContents を取得
       const webContents = event.sender
       // 応答チャンネル名を生成
@@ -167,10 +156,7 @@ const createRegisterEvent = <TElectronMainApi extends Api>(
         // 登録
 
         // すでに登録されている場合は何もしない
-        if (
-          cache.has(webContents) &&
-          cache.get(webContents)!.has(responseChannel)
-        ) {
+        if (cache.has(webContents) && cache.get(webContents)!.has(responseChannel)) {
           return false
         }
 
@@ -196,10 +182,7 @@ const createRegisterEvent = <TElectronMainApi extends Api>(
         // 登録解除
 
         // 登録されていない場合は何もしない
-        if (
-          !cache.has(webContents) ||
-          !cache.get(webContents)!.has(responseChannel)
-        ) {
+        if (!cache.has(webContents) || !cache.get(webContents)!.has(responseChannel)) {
           return false
         }
 
@@ -234,8 +217,7 @@ export const createRegisterIpc =
   ({ getContext, cache }) => {
     const map = createRegistrationMap({
       getContext,
-      defineHelper: <T extends IpcRegistrationMap<TElectronMainApi>>(map: T) =>
-        map,
+      defineHelper: <T extends IpcRegistrationMap<TElectronMainApi>>(map: T) => map,
     })
 
     for (const channel of Object.keys(map) as Array<keyof typeof map>) {
@@ -243,10 +225,7 @@ export const createRegisterIpc =
       if (entry.type === 'invoke') {
         createRegisterInvoke<TElectronMainApi>()(channel, entry.method)
       } else if (entry.type === 'event') {
-        createRegisterEvent<TElectronMainApi>(cache)(
-          channel,
-          entry.addEventListener,
-        )
+        createRegisterEvent<TElectronMainApi>(cache)(channel, entry.addEventListener)
       }
     }
   }

--- a/electron/shared/lib/ipc/shared/types.ts
+++ b/electron/shared/lib/ipc/shared/types.ts
@@ -11,9 +11,7 @@ export type RemoveListener = () => void
 
 export type Listener<TArg extends any = any> = (arg: TArg) => void
 
-export type AddListener<TArg extends any = any> = (
-  listener: Listener<TArg>,
-) => RemoveListener
+export type AddListener<TArg extends any = any> = (listener: Listener<TArg>) => RemoveListener
 
 /**
  * 任意の関数型
@@ -131,10 +129,7 @@ export type RecursiveMethodKeys<T> = T extends Api
  * type Result3 = PathValue<ExampleType, 'b.b2'>
  * // () => string[]
  */
-export type PathValue<
-  T,
-  P extends string,
-> = P extends `${infer K}.${infer Rest}`
+export type PathValue<T, P extends string> = P extends `${infer K}.${infer Rest}`
   ? K extends keyof T
     ? PathValue<T[K], Rest>
     : never
@@ -168,13 +163,8 @@ export type PathValue<
  * type Result3 = ExtractMethod<ExampleType, 'b.b2'>
  * // () => string[]
  */
-export type ExtractMethod<
-  TApiType extends Api,
-  TMethodKey extends RecursiveMethodKeys<TApiType>,
-> =
-  PathValue<TApiType, TMethodKey> extends (
-    ...args: infer TArgs
-  ) => infer TReturn
+export type ExtractMethod<TApiType extends Api, TMethodKey extends RecursiveMethodKeys<TApiType>> =
+  PathValue<TApiType, TMethodKey> extends (...args: infer TArgs) => infer TReturn
     ? (...args: TArgs) => TReturn
     : never
 
@@ -252,9 +242,7 @@ export type IpcEventEntry<
   TChannel extends RecursiveMethodKeys<TElectronMainApi>,
 > = {
   type: 'event'
-  addEventListener: WithWebContents<
-    ExtractAddListener<TElectronMainApi, TChannel>
-  >
+  addEventListener: WithWebContents<ExtractAddListener<TElectronMainApi, TChannel>>
 }
 
 export type IpcRegistrationMap<TElectronMainApi extends Api> = {

--- a/electron/shared/lib/rag/ingest.ts
+++ b/electron/shared/lib/rag/ingest.ts
@@ -1,3 +1,5 @@
+import type { DatabaseSync } from 'node:sqlite'
+
 import ollama from 'ollama'
 
 // -----------------------------------------------------------------------------
@@ -268,8 +270,8 @@ async function createHandlersWithNodeSqlite(
 }> {
   const { DatabaseSync } = await import('node:sqlite')
 
-  let db: import('node:sqlite').DatabaseSync | null = null
-  let insertStmt: ReturnType<import('node:sqlite').DatabaseSync['prepare']> | null = null
+  let db: DatabaseSync | null = null
+  let insertStmt: ReturnType<DatabaseSync['prepare']> | null = null
 
   const initialize = () => {
     if (db) {

--- a/electron/shared/lib/rag/ingest.ts
+++ b/electron/shared/lib/rag/ingest.ts
@@ -24,10 +24,7 @@ export type Handlers = {
   finalize: Finalize
 }
 
-export type CreateHandlers = (
-  dbPath: string,
-  docName: string,
-) => Handlers | Promise<Handlers>
+export type CreateHandlers = (dbPath: string, docName: string) => Handlers | Promise<Handlers>
 
 export type IngestDocumentsOptions = {
   /** データベースファイルのパス */
@@ -117,10 +114,7 @@ VALUES (?, ?, ?, ?, ?)`
  * @param text 取り込むテキスト
  * @param options 取り込みオプション
  */
-export async function ingestDocuments(
-  text: string,
-  options: IngestDocumentsOptions,
-) {
+export async function ingestDocuments(text: string, options: IngestDocumentsOptions) {
   const {
     dbPath,
     docName,
@@ -152,11 +146,7 @@ export async function ingestDocuments(
       continue
     }
 
-    const subChunks = splitForEmbedding(
-      content,
-      maxEmbeddingChars,
-      embeddingOverlap,
-    )
+    const subChunks = splitForEmbedding(content, maxEmbeddingChars, embeddingOverlap)
 
     // サブチャンクごとに処理する
     for (let subIdx = 0; subIdx < subChunks.length; subIdx++) {
@@ -193,11 +183,7 @@ export async function ingestDocuments(
  * @param overlap スライス間のオーバーラップ（文字数）
  * @returns スライスの配列（空文字列のスライスは除外される）
  */
-function sliceWithOverlap(
-  text: string,
-  size: number,
-  overlap: number,
-): Array<string> {
+function sliceWithOverlap(text: string, size: number, overlap: number): Array<string> {
   const slices: Array<string> = []
   let i = 0
 
@@ -283,9 +269,7 @@ async function createHandlersWithNodeSqlite(
   const { DatabaseSync } = await import('node:sqlite')
 
   let db: import('node:sqlite').DatabaseSync | null = null
-  let insertStmt: ReturnType<
-    import('node:sqlite').DatabaseSync['prepare']
-  > | null = null
+  let insertStmt: ReturnType<import('node:sqlite').DatabaseSync['prepare']> | null = null
 
   const initialize = () => {
     if (db) {

--- a/electron/shared/lib/rag/retrieve.ts
+++ b/electron/shared/lib/rag/retrieve.ts
@@ -55,10 +55,7 @@ export type RetrieveRagContextOptions = {
    * }
    * ```
    */
-  loadChunks?: (
-    dbPath: string,
-    docName: string,
-  ) => Array<ChunkRow> | Promise<Array<ChunkRow>>
+  loadChunks?: (dbPath: string, docName: string) => Array<ChunkRow> | Promise<Array<ChunkRow>>
 
   /** 使用する埋め込みモデル（例: 'nomic-embed-text-v2-moe:latest'） */
   model: string
@@ -164,16 +161,11 @@ function assertType<T extends keyof TypeMap>(
   fieldName: string,
 ): asserts value is TypeMap[T] {
   if (typeof value !== expected) {
-    throw new Error(
-      `Invalid ${fieldName} in chunk row: expected ${expected}, got ${typeof value}`,
-    )
+    throw new Error(`Invalid ${fieldName} in chunk row: expected ${expected}, got ${typeof value}`)
   }
 }
 
-async function loadChunksWithNodeSqlite(
-  dbPath: string,
-  docName: string,
-): Promise<Array<ChunkRow>> {
+async function loadChunksWithNodeSqlite(dbPath: string, docName: string): Promise<Array<ChunkRow>> {
   // 動的インポートを使用して、node:sqliteのDatabaseSyncクラスを読み込む
   // import { DatabaseSync } from 'node:sqlite'
   const { DatabaseSync } = await import('node:sqlite')
@@ -181,14 +173,7 @@ async function loadChunksWithNodeSqlite(
   const stmt = db.prepare(SQL_SELECT_CHUNKS)
   const rows = stmt.all(docName)
   const result = rows.map((row) => {
-    const {
-      id,
-      doc_name,
-      source_chunk_index,
-      sub_index,
-      content,
-      embedding_json,
-    } = row
+    const { id, doc_name, source_chunk_index, sub_index, content, embedding_json } = row
 
     assertType(id, 'number', 'id')
     assertType(doc_name, 'string', 'doc_name')
@@ -196,8 +181,7 @@ async function loadChunksWithNodeSqlite(
     assertType(sub_index, 'number', 'sub_index')
     assertType(content, 'string', 'content')
 
-    const embeddingJson =
-      typeof embedding_json === 'string' ? embedding_json : '[]'
+    const embeddingJson = typeof embedding_json === 'string' ? embedding_json : '[]'
     const embedding = JSON.parse(embeddingJson) as Array<number>
 
     return {
@@ -219,10 +203,7 @@ async function loadChunksWithNodeSqlite(
  * @param query
  * @param options
  */
-async function embedQuery(
-  query: string,
-  options: { model: string; queryPrefix: string },
-) {
+async function embedQuery(query: string, options: { model: string; queryPrefix: string }) {
   const { model, queryPrefix } = options
   const res = await ollama.embeddings({
     model,
@@ -244,9 +225,7 @@ async function embedQuery(
  */
 function cosineSimilarity(vecA: Array<number>, vecB: Array<number>): number {
   if (vecA.length !== vecB.length) {
-    throw new Error(
-      `ベクトルの次元数が一致しません: vecA=${vecA.length}, vecB=${vecB.length}`,
-    )
+    throw new Error(`ベクトルの次元数が一致しません: vecA=${vecA.length}, vecB=${vecB.length}`)
   }
 
   let dot = 0 // ベクトルの内積

--- a/electron/shared/lib/tanstack-ai-mcp/index.ts
+++ b/electron/shared/lib/tanstack-ai-mcp/index.ts
@@ -1,19 +1,16 @@
-import { toolDefinition, type ServerTool } from '@tanstack/ai'
-import {
-  type ListToolsRequest,
-  type Tool as McpTool,
-} from '@modelcontextprotocol/sdk/types.js'
-import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
 import { Client } from '@modelcontextprotocol/sdk/client'
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
-import {
-  StreamableHTTPClientTransport,
-  type StreamableHTTPClientTransportOptions,
-} from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import {
   StdioClientTransport,
   type StdioServerParameters,
 } from '@modelcontextprotocol/sdk/client/stdio.js'
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { type ListToolsRequest, type Tool as McpTool } from '@modelcontextprotocol/sdk/types.js'
+import { toolDefinition, type ServerTool } from '@tanstack/ai'
 
 type ListToolsOptions = {
   params?: ListToolsRequest['params']
@@ -58,22 +55,13 @@ export async function mcpToTanStackAiTools(
       },
 ): Promise<ServerTool[]> {
   if ('stdioOptions' in options) {
-    return mcpToTanStackAiTools_stdio(
-      options.stdioOptions,
-      options.listToolsOptions,
-    )
+    return mcpToTanStackAiTools_stdio(options.stdioOptions, options.listToolsOptions)
   } else if ('httpOptions' in options) {
-    return mcpToTanStackAiTools_http(
-      options.httpOptions,
-      options.listToolsOptions,
-    )
+    return mcpToTanStackAiTools_http(options.httpOptions, options.listToolsOptions)
   } else if ('client' in options) {
     return mcpToTanStackAiTools_client(options.client, options.listToolsOptions)
   } else if ('transport' in options) {
-    return mcpToTanStackAiTools_transport(
-      options.transport,
-      options.listToolsOptions,
-    )
+    return mcpToTanStackAiTools_transport(options.transport, options.listToolsOptions)
   } else {
     throw new Error('Invalid options provided to mcpToTanStackAiTools')
   }
@@ -101,10 +89,7 @@ async function mcpToTanStackAiTools_http(
     version: '1',
   })
   const { url, ...transportOptions } = httpOptions
-  const transport = new StreamableHTTPClientTransport(
-    new URL(url),
-    transportOptions,
-  )
+  const transport = new StreamableHTTPClientTransport(new URL(url), transportOptions)
   await client.connect(transport)
   return mcpToTanStackAiTools_client(client, listToolsOptions)
 }
@@ -121,18 +106,12 @@ async function mcpToTanStackAiTools_transport(
   return mcpToTanStackAiTools_client(client, listToolsOptions)
 }
 
-async function mcpToTanStackAiTools_client(
-  client: Client,
-  listToolsOptions?: ListToolsOptions,
-) {
+async function mcpToTanStackAiTools_client(client: Client, listToolsOptions?: ListToolsOptions) {
   const mcpTools = await retrieveMcpTools(client, listToolsOptions)
   return mcpToolsToTanStackAiTools(mcpTools, client)
 }
 
-export async function retrieveMcpTools(
-  client: Client,
-  listToolsOptions?: ListToolsOptions,
-) {
+export async function retrieveMcpTools(client: Client, listToolsOptions?: ListToolsOptions) {
   const { params = {}, options = {} } = listToolsOptions ?? {}
   let cursor: string | undefined
   const allTools: McpTool[] = []

--- a/electron/shared/lib/tanstack-ai-mcp/index.ts
+++ b/electron/shared/lib/tanstack-ai-mcp/index.ts
@@ -1,16 +1,13 @@
 import { Client } from '@modelcontextprotocol/sdk/client'
-import {
-  StdioClientTransport,
-  type StdioServerParameters,
-} from '@modelcontextprotocol/sdk/client/stdio.js'
-import {
-  StreamableHTTPClientTransport,
-  type StreamableHTTPClientTransportOptions,
-} from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import type { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
-import { type ListToolsRequest, type Tool as McpTool } from '@modelcontextprotocol/sdk/types.js'
-import { toolDefinition, type ServerTool } from '@tanstack/ai'
+import type { ListToolsRequest, Tool as McpTool } from '@modelcontextprotocol/sdk/types.js'
+import { toolDefinition } from '@tanstack/ai'
+import type { ServerTool } from '@tanstack/ai'
 
 type ListToolsOptions = {
   params?: ListToolsRequest['params']

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist-electron/main/index.js",
   "scripts": {
     "dev": "vite",
-    "build": "tsgo && vite build && electron-builder",
+    "build": "pnpm lint && vite build && electron-builder",
     "test": "tsgo --noEmit && vitest run",
     "lint": "tsgo --noEmit && oxlint",
     "format": "oxfmt",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "your-app-name",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/index.js",

--- a/scripts/rag/answer-with-rag.ts
+++ b/scripts/rag/answer-with-rag.ts
@@ -1,6 +1,8 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import ollama from 'ollama'
+
 import { retrieveRagContext } from '../../electron/shared/lib/rag/retrieve.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -19,9 +21,7 @@ async function main() {
     queryPrefix: 'search_query:',
     topK: 3,
   })
-  const context = result
-    .map((item) => `${item.content}\n【${item.score}】\n`)
-    .join('')
+  const context = result.map((item) => `${item.content}\n【${item.score}】\n`).join('')
 
   const res = await ollama.chat({
     model: 'gpt-oss:20b-cloud',

--- a/scripts/rag/run-ingest-json.ts
+++ b/scripts/rag/run-ingest-json.ts
@@ -1,6 +1,7 @@
-import path from 'node:path'
 import fs from 'node:fs/promises'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import { ingestDocuments } from '../../electron/shared/lib/rag/ingest.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -27,13 +28,7 @@ async function main() {
       const data: Array<ChunkEntry> = []
       return {
         initialize: () => {},
-        insert: (
-          docName,
-          sourceChunkIndex,
-          subIndex,
-          content,
-          embeddingJson,
-        ) => {
+        insert: (docName, sourceChunkIndex, subIndex, content, embeddingJson) => {
           data.push({
             docName,
             sourceChunkIndex,

--- a/scripts/rag/run-ingest-sqlite.ts
+++ b/scripts/rag/run-ingest-sqlite.ts
@@ -1,6 +1,7 @@
-import path from 'node:path'
 import fs from 'node:fs/promises'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import { ingestDocuments } from '../../electron/shared/lib/rag/ingest.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/scripts/rag/run-retrieve-json.ts
+++ b/scripts/rag/run-retrieve-json.ts
@@ -1,6 +1,7 @@
-import path from 'node:path'
 import fs from 'node:fs/promises'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import { retrieveRagContext } from '../../electron/shared/lib/rag/retrieve.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -23,8 +24,6 @@ async function main() {
     queryPrefix: 'search_query:',
     topK: 3,
   })
-  const formattedResult = result
-    .map((item) => `${item.content}\n【${item.score}】\n`)
-    .join('')
+  const formattedResult = result.map((item) => `${item.content}\n【${item.score}】\n`).join('')
   console.log(formattedResult)
 }

--- a/scripts/rag/run-retrieve-sqlite.ts
+++ b/scripts/rag/run-retrieve-sqlite.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import { retrieveRagContext } from '../../electron/shared/lib/rag/retrieve.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -18,8 +19,6 @@ async function main() {
     queryPrefix: 'search_query:',
     topK: 3,
   })
-  const formattedResult = result
-    .map((item) => `${item.content}\n【${item.score}】\n`)
-    .join('')
+  const formattedResult = result.map((item) => `${item.content}\n【${item.score}】\n`).join('')
   console.log(formattedResult)
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,4 @@
-import {
-  registerAuthStatusResponder,
-  requestAuthStatusFromParent,
-} from '@/lib/frame-rpc'
+import { registerAuthStatusResponder, requestAuthStatusFromParent } from '@/lib/frame-rpc'
 
 export type Api = typeof window.api
 export type AiChatApi = Api['aiChat']
@@ -48,14 +45,10 @@ const api: Api = (() => {
       {},
       {
         get() {
-          throw new Error(
-            `[api] '${name}' は Electron 環境でのみ利用可能です。`,
-          )
+          throw new Error(`[api] '${name}' は Electron 環境でのみ利用可能です。`)
         },
         apply() {
-          throw new Error(
-            `[api] '${name}' は Electron 環境でのみ利用可能です。`,
-          )
+          throw new Error(`[api] '${name}' は Electron 環境でのみ利用可能です。`)
         },
       },
     ) as unknown
@@ -88,9 +81,7 @@ const api: Api = (() => {
     auth: isIframe
       ? {
           getStatus: async () =>
-            await requestAuthStatusFromParent<
-              Awaited<ReturnType<AuthApi['getStatus']>>
-            >({
+            await requestAuthStatusFromParent<Awaited<ReturnType<AuthApi['getStatus']>>>({
               timeoutMs: 3000,
             }),
           login: () => {

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+
+import { Link, useLocation } from '@tanstack/react-router'
 import {
   BookOpen,
   Frame,
@@ -9,8 +11,8 @@ import {
   PieChart,
   ToggleLeftIcon,
 } from 'lucide-react'
-import { Link, useLocation } from '@tanstack/react-router'
 
+import logo from '@/assets/logo.svg'
 import { NavMain } from '@/components/nav-main'
 import { NavUser } from '@/components/nav-user'
 import {
@@ -28,8 +30,6 @@ import { useAuth } from '@/features/auth/api/auth'
 import { OpenChat } from '@/features/chat/components/open-chat'
 import { components } from '@/features/ui-demo/constants'
 import { formatKebabAsTitle } from '@/lib/format-kebab-as-title'
-
-import logo from '@/assets/logo.svg'
 
 // This is sample data.
 const data = {

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -1,5 +1,7 @@
-import { Link, isMatch, useLocation, useMatches } from '@tanstack/react-router'
 import React from 'react'
+
+import { Link, isMatch, useLocation, useMatches } from '@tanstack/react-router'
+
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -48,9 +50,7 @@ export const Breadcrumbs = () => {
     return null
   }
 
-  const matchesWithCrumbs = matches.filter((match) =>
-    isMatch(match, 'loaderData.crumb'),
-  )
+  const matchesWithCrumbs = matches.filter((match) => isMatch(match, 'loaderData.crumb'))
 
   return (
     <Breadcrumb>

--- a/src/components/devtools-provider.tsx
+++ b/src/components/devtools-provider.tsx
@@ -18,8 +18,7 @@ const initialState: DevToolsProviderState = {
   show: () => {},
 }
 
-const DevToolsProviderContext =
-  createContext<DevToolsProviderState>(initialState)
+const DevToolsProviderContext = createContext<DevToolsProviderState>(initialState)
 
 export function DevToolsProvider({
   children,
@@ -51,12 +50,9 @@ export function DevToolsProvider({
 }
 
 export const useDevTools = () => {
-  const context = useContext(DevToolsProviderContext) as
-    | DevToolsProviderState
-    | undefined
+  const context = useContext(DevToolsProviderContext) as DevToolsProviderState | undefined
 
-  if (context === undefined)
-    throw new Error('useDevTools must be used within a DevToolsProvider')
+  if (context === undefined) throw new Error('useDevTools must be used within a DevToolsProvider')
 
   return context
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,14 +1,10 @@
 import React from 'react'
-import { Breadcrumbs } from './breadcrumbs'
-import { AppSidebar } from '@/components/app-sidebar'
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-  useSidebar,
-} from '@/components/ui/sidebar'
 
+import { AppSidebar } from '@/components/app-sidebar'
+import { SidebarInset, SidebarProvider, SidebarTrigger, useSidebar } from '@/components/ui/sidebar'
 import { cn } from '@/lib/utils'
+
+import { Breadcrumbs } from './breadcrumbs'
 
 export function Layout(props: { children?: React.ReactNode }) {
   const { children } = props

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,14 +1,10 @@
 'use client'
 
-import { ChevronRight } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
+import { ChevronRight } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import {
   SidebarGroup,
   SidebarMenu,
@@ -51,10 +47,7 @@ export function NavMain({
                   <CollapsibleTrigger asChild>
                     <SidebarMenuButton tooltip={item.title}>
                       {item.icon && <item.icon />}
-                      <Link
-                        to={item.url}
-                        className="[&.active]:font-bold hover:font-bold"
-                      >
+                      <Link to={item.url} className="[&.active]:font-bold hover:font-bold">
                         <span>{item.title}</span>
                       </Link>
                       <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
@@ -66,18 +59,11 @@ export function NavMain({
                         <SidebarMenuSubItem key={subItem.title}>
                           <SidebarMenuSubButton asChild>
                             {subItem.externalLink ? (
-                              <a
-                                href={subItem.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
+                              <a href={subItem.url} target="_blank" rel="noopener noreferrer">
                                 <span>{subItem.title}</span>
                               </a>
                             ) : (
-                              <Link
-                                to={subItem.url}
-                                className="[&.active]:font-bold"
-                              >
+                              <Link to={subItem.url} className="[&.active]:font-bold">
                                 <span>{subItem.title}</span>
                               </Link>
                             )}
@@ -90,10 +76,7 @@ export function NavMain({
               ) : (
                 <SidebarMenuButton tooltip={item.title}>
                   {item.icon && <item.icon />}
-                  <Link
-                    to={item.url}
-                    className="[&.active]:font-bold hover:font-bold"
-                  >
+                  <Link to={item.url} className="[&.active]:font-bold hover:font-bold">
                     <span>{item.title}</span>
                   </Link>
                 </SidebarMenuButton>

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -1,5 +1,5 @@
-import { ChevronsUpDown, LogOut, Settings2Icon } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
+import { ChevronsUpDown, LogOut, Settings2Icon } from 'lucide-react'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
@@ -44,9 +44,7 @@ export function NavUser({
             >
               <Avatar className="h-8 w-8 rounded-lg">
                 <AvatarImage src={user.avatar} alt={user.name} />
-                <AvatarFallback className="rounded-lg">
-                  {avatarAlt}
-                </AvatarFallback>
+                <AvatarFallback className="rounded-lg">{avatarAlt}</AvatarFallback>
               </Avatar>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{user.name}</span>
@@ -65,9 +63,7 @@ export function NavUser({
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <Avatar className="h-8 w-8 rounded-lg">
                   <AvatarImage src={user.avatar} alt={user.name} />
-                  <AvatarFallback className="rounded-lg">
-                    {avatarAlt}
-                  </AvatarFallback>
+                  <AvatarFallback className="rounded-lg">{avatarAlt}</AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-medium">{user.name}</span>

--- a/src/components/table/basic-table.tsx
+++ b/src/components/table/basic-table.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+
 import { createColumnHelper, flexRender } from '@tanstack/react-table'
+import type { CellContext, Column, Header, HeaderContext, Table } from '@tanstack/react-table'
 import {
   ArrowDown,
   ArrowDownUp,
@@ -17,27 +19,17 @@ import {
   PinOffIcon,
 } from 'lucide-react'
 
-import { NativeSelect, NativeSelectOption } from '../ui/native-select'
-import { Input } from '../ui/input'
-import { Separator } from '../ui/separator'
-import type {
-  CellContext,
-  Column,
-  Header,
-  HeaderContext,
-  Table,
-} from '@tanstack/react-table'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import { Checkbox } from '@/components/ui/checkbox'
-import { Label } from '@/components/ui/label'
-import { Button } from '@/components/ui/button'
 import { DebouncedInput } from '@/components/table/debounced-input'
 import { Filter } from '@/components/table/filter'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
+
+import { Input } from '../ui/input'
+import { NativeSelect, NativeSelectOption } from '../ui/native-select'
+import { Separator } from '../ui/separator'
 
 export function BasicTable<T>(props: {
   table: Table<T>
@@ -70,8 +62,7 @@ export function BasicTable<T>(props: {
     const columns = prev.columns
 
     const firstId = (columns[0] as any)?.id
-    const hasPin =
-      firstId === '__pin' || columns.some((col: any) => col?.id === '__pin')
+    const hasPin = firstId === '__pin' || columns.some((col: any) => col?.id === '__pin')
     const needsResizeMode = prev.columnResizeMode !== 'onChange'
 
     // 変更がない場合は高速パス - ページネーションの自動リセットを回避します。
@@ -116,10 +107,8 @@ export function BasicTable<T>(props: {
   // View the index.css file for more needed styles such as border-collapse: separate
   const getCommonPinningStyles = (column: Column<T>): React.CSSProperties => {
     const isPinned = column.getIsPinned()
-    const isLastLeftPinnedColumn =
-      isPinned === 'left' && column.getIsLastColumn('left')
-    const isFirstRightPinnedColumn =
-      isPinned === 'right' && column.getIsFirstColumn('right')
+    const isLastLeftPinnedColumn = isPinned === 'left' && column.getIsLastColumn('left')
+    const isFirstRightPinnedColumn = isPinned === 'right' && column.getIsFirstColumn('right')
 
     return {
       boxShadow: isLastLeftPinnedColumn
@@ -149,15 +138,9 @@ export function BasicTable<T>(props: {
             onChangeGlobalFilter={handleChangeGlobalFilter}
           />
         </div>
-        <Button
-          variant="outline"
-          size="default"
-          onClick={() => setShowFilters(!showFilters)}
-        >
+        <Button variant="outline" size="default" onClick={() => setShowFilters(!showFilters)}>
           <ListFilter />
-          <span className="ml-2">
-            {showFilters ? 'フィルターを非表示' : 'フィルターを表示'}
-          </span>
+          <span className="ml-2">{showFilters ? 'フィルターを非表示' : 'フィルターを表示'}</span>
         </Button>
         <GlobalColumnVisibilityToggle table={table} />
         <GlobalTableControls
@@ -177,32 +160,23 @@ export function BasicTable<T>(props: {
             '--table-height': '80vh',
           } as React.CSSProperties
         }
-        className={cn(
-          'w-full rounded-lg border border-border overflow-auto overscroll-none',
-          {
-            'h-(--table-height)': isTableHeightFixed,
-          },
-        )}
+        className={cn('w-full rounded-lg border border-border overflow-auto overscroll-none', {
+          'h-(--table-height)': isTableHeightFixed,
+        })}
       >
         <table
-          className={cn(
-            'text-sm text-foreground table-fixed border-spacing-0 border-separate',
-            {
-              'min-w-full': isTableWidthFull,
-              'w-full': isTableWidthFull,
-              'w-(--table-total-width)': !isTableWidthFull,
-            },
-          )}
+          className={cn('text-sm text-foreground table-fixed border-spacing-0 border-separate', {
+            'min-w-full': isTableWidthFull,
+            'w-full': isTableWidthFull,
+            'w-(--table-total-width)': !isTableWidthFull,
+          })}
         >
           <TableHeader
             table={table}
             showFilters={showFilters}
             getCommonPinningStyles={getCommonPinningStyles}
           />
-          <TableBody
-            table={table}
-            getCommonPinningStyles={getCommonPinningStyles}
-          />
+          <TableBody table={table} getCommonPinningStyles={getCommonPinningStyles} />
         </table>
       </div>
       <div className="h-4" />
@@ -305,9 +279,7 @@ function GlobalColumnVisibilityToggle<T>(props: { table: Table<T> }) {
                   }
                 }}
               />
-              {typeof column.columnDef.header === 'string'
-                ? column.columnDef.header
-                : column.id}
+              {typeof column.columnDef.header === 'string' ? column.columnDef.header : column.id}
             </Label>
           </div>
         ))}
@@ -364,11 +336,7 @@ function GlobalTableControls<T>(props: {
         >
           <div>
             <span>テーブルの高さを</span>
-            {isTableHeightFixed ? (
-              <span>固定しない</span>
-            ) : (
-              <span>固定する</span>
-            )}
+            {isTableHeightFixed ? <span>固定しない</span> : <span>固定する</span>}
           </div>
         </Button>
         <Button
@@ -496,10 +464,7 @@ function TableHeader<T>(props: {
                         onClick={header.column.getToggleSortingHandler()}
                       >
                         <div className="flex-1 truncate">
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
+                          {flexRender(header.column.columnDef.header, header.getContext())}
                         </div>
                         {header.column.getCanSort() && (
                           <div className="w-4 flex items-center justify-center">
@@ -512,17 +477,14 @@ function TableHeader<T>(props: {
                           </div>
                         )}
                       </div>
-                      {header.column.getCanFilter() &&
-                        header.column.getIsFiltered() && (
-                          <div
-                            className="w-4 flex items-center justify-center hover:text-blue-400 cursor-pointer"
-                            onClick={() =>
-                              header.column.setFilterValue(undefined)
-                            }
-                          >
-                            <FilterXIcon />
-                          </div>
-                        )}
+                      {header.column.getCanFilter() && header.column.getIsFiltered() && (
+                        <div
+                          className="w-4 flex items-center justify-center hover:text-blue-400 cursor-pointer"
+                          onClick={() => header.column.setFilterValue(undefined)}
+                        >
+                          <FilterXIcon />
+                        </div>
+                      )}
                       <div className="w-4 flex items-center justify-center">
                         <HeaderActionMenu header={header} />
                       </div>
@@ -575,10 +537,7 @@ function HeaderActionMenu<T>(props: { header: Header<T, unknown> }) {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <EllipsisVertical
-          size="16"
-          className="hover:text-blue-400 cursor-pointer"
-        />
+        <EllipsisVertical size="16" className="hover:text-blue-400 cursor-pointer" />
       </PopoverTrigger>
       <PopoverContent className="p-2 bg-background text-foreground flex flex-col min-h-64 justify-start items-start gap-2">
         <Button
@@ -586,9 +545,7 @@ function HeaderActionMenu<T>(props: { header: Header<T, unknown> }) {
           variant="outline"
           size="default"
           onClick={() => header.column.setFilterValue(undefined)}
-          disabled={
-            !header.column.getCanFilter() || !header.column.getIsFiltered()
-          }
+          disabled={!header.column.getCanFilter() || !header.column.getIsFiltered()}
         >
           <FilterXIcon className="inline mr-1" />
           フィルターをクリア
@@ -608,9 +565,7 @@ function HeaderActionMenu<T>(props: { header: Header<T, unknown> }) {
           variant="outline"
           size="default"
           onClick={() => header.column.pin('left')}
-          disabled={
-            !header.column.getCanPin() || header.column.getIsPinned() === 'left'
-          }
+          disabled={!header.column.getCanPin() || header.column.getIsPinned() === 'left'}
         >
           <PinIcon className="inline mr-1" />
           列を左に固定
@@ -620,10 +575,7 @@ function HeaderActionMenu<T>(props: { header: Header<T, unknown> }) {
           variant="outline"
           size="default"
           onClick={() => header.column.pin('right')}
-          disabled={
-            !header.column.getCanPin() ||
-            header.column.getIsPinned() === 'right'
-          }
+          disabled={!header.column.getCanPin() || header.column.getIsPinned() === 'right'}
         >
           <PinIcon className="inline mr-1" />
           列を右に固定
@@ -633,9 +585,7 @@ function HeaderActionMenu<T>(props: { header: Header<T, unknown> }) {
           variant="outline"
           size="default"
           onClick={() => header.column.pin(false)}
-          disabled={
-            !header.column.getCanPin() || header.column.getIsPinned() === false
-          }
+          disabled={!header.column.getCanPin() || header.column.getIsPinned() === false}
         >
           <PinOffIcon className="inline mr-1" />
           列の固定を解除
@@ -666,18 +616,13 @@ function TableBody<T>(props: {
         return (
           <tr
             key={row.id}
-            className={cn(
-              'transition-colors group h-12 [&:last-child_td]:border-b-0',
-              {
-                sticky: row.getIsPinned() === 'top',
-                'z-15': row.getIsPinned() === 'top',
-              },
-            )}
+            className={cn('transition-colors group h-12 [&:last-child_td]:border-b-0', {
+              sticky: row.getIsPinned() === 'top',
+              'z-15': row.getIsPinned() === 'top',
+            })}
             style={{
               top:
-                row.getIsPinned() === 'top'
-                  ? `${row.getPinnedIndex() * 48 + 48 + 1}px`
-                  : undefined,
+                row.getIsPinned() === 'top' ? `${row.getPinnedIndex() * 48 + 48 + 1}px` : undefined,
             }}
           >
             {row.getVisibleCells().map((cell) => {
@@ -704,10 +649,7 @@ function TableBody<T>(props: {
       })}
       {table.getCenterRows().map((row) => {
         return (
-          <tr
-            key={row.id}
-            className="transition-colors group h-12 [&:last-child_td]:border-b-0"
-          >
+          <tr key={row.id} className="transition-colors group h-12 [&:last-child_td]:border-b-0">
             {row.getVisibleCells().map((cell) => {
               return (
                 <td
@@ -810,10 +752,7 @@ function Pagination<T>(props: { table: Table<T> }) {
           value={table.getState().pagination.pageIndex + 1}
         />
       </Label>
-      <NativeSelect
-        value={table.getState().pagination.pageSize}
-        onChange={handlePageSizeChange}
-      >
+      <NativeSelect value={table.getState().pagination.pageSize} onChange={handlePageSizeChange}>
         {[10, 20, 30, 40, 50].map((pageSize) => (
           <NativeSelectOption key={pageSize} value={pageSize}>
             {pageSize} 件 / ページ
@@ -824,20 +763,14 @@ function Pagination<T>(props: { table: Table<T> }) {
   )
 }
 
-function DebugInfo<T>(props: {
-  table: Table<T>
-  rerender?: () => void
-  refreshData?: () => void
-}) {
+function DebugInfo<T>(props: { table: Table<T>; rerender?: () => void; refreshData?: () => void }) {
   'use no memo'
 
   const { table, rerender, refreshData } = props
 
   return (
     <>
-      <div className="mt-4 text-gray-400">
-        {table.getPrePaginationRowModel().rows.length} Rows
-      </div>
+      <div className="mt-4 text-gray-400">{table.getPrePaginationRowModel().rows.length} Rows</div>
       <div className="mt-4 flex gap-2">
         {rerender && (
           <button

--- a/src/components/table/debounced-input.test.tsx
+++ b/src/components/table/debounced-input.test.tsx
@@ -12,9 +12,7 @@ describe('DebouncedInput', () => {
     vi.useFakeTimers()
 
     const onChange1 = vi.fn()
-    const { rerender } = render(
-      <DebouncedInput value="abc" onChange={onChange1} debounce={10} />,
-    )
+    const { rerender } = render(<DebouncedInput value="abc" onChange={onChange1} debounce={10} />)
 
     vi.advanceTimersByTime(10)
     expect(onChange1).not.toHaveBeenCalled()
@@ -35,9 +33,7 @@ describe('DebouncedInput', () => {
     vi.useFakeTimers()
 
     const onChange = vi.fn()
-    const { getByRole } = render(
-      <DebouncedInput value="" onChange={onChange} debounce={10} />,
-    )
+    const { getByRole } = render(<DebouncedInput value="" onChange={onChange} debounce={10} />)
 
     vi.advanceTimersByTime(10)
     expect(onChange).not.toHaveBeenCalled()

--- a/src/components/table/debounced-input.tsx
+++ b/src/components/table/debounced-input.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { Input } from '@/components/ui/input'
 
 // 一般的なdebounce付きのinputコンポーネント

--- a/src/components/table/filter.tsx
+++ b/src/components/table/filter.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+
 import type { Column } from '@tanstack/react-table'
+
 import { DebouncedInput } from '@/components/table/debounced-input'
 import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select'
 
@@ -8,18 +10,13 @@ export function Filter({ column }: { column: Column<any, unknown> }) {
 
   const { filterVariant } = column.columnDef.meta ?? {}
 
-  const columnFilterValue = column.getFilterValue() as
-    | [number, number]
-    | string
-    | null
+  const columnFilterValue = column.getFilterValue() as [number, number] | string | null
 
   const sortedUniqueValues = React.useMemo(
     () =>
       filterVariant === 'range'
         ? []
-        : Array.from(column.getFacetedUniqueValues().keys())
-            .sort()
-            .slice(0, 5000),
+        : Array.from(column.getFacetedUniqueValues().keys()).sort().slice(0, 5000),
     [column, filterVariant],
   )
 
@@ -31,9 +28,7 @@ export function Filter({ column }: { column: Column<any, unknown> }) {
           min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
           max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
           value={columnFilterValue?.[0] ?? ''}
-          onChange={(value) =>
-            column.setFilterValue((old: [number, number]) => [value, old[1]])
-          }
+          onChange={(value) => column.setFilterValue((old: [number, number]) => [value, old[1]])}
           placeholder={`Min ${
             column.getFacetedMinMaxValues()?.[0] !== undefined
               ? `(${column.getFacetedMinMaxValues()?.[0]})`
@@ -45,13 +40,9 @@ export function Filter({ column }: { column: Column<any, unknown> }) {
           min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
           max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
           value={columnFilterValue?.[1] ?? ''}
-          onChange={(value) =>
-            column.setFilterValue((old: [number, number]) => [old[0], value])
-          }
+          onChange={(value) => column.setFilterValue((old: [number, number]) => [old[0], value])}
           placeholder={`Max ${
-            column.getFacetedMinMaxValues()?.[1]
-              ? `(${column.getFacetedMinMaxValues()?.[1]})`
-              : ''
+            column.getFacetedMinMaxValues()?.[1] ? `(${column.getFacetedMinMaxValues()?.[1]})` : ''
           }`}
         />
       </div>

--- a/src/components/table/tableUtils.ts
+++ b/src/components/table/tableUtils.ts
@@ -1,6 +1,5 @@
-import { sortingFns } from '@tanstack/react-table'
 import { compareItems, rankItem } from '@tanstack/match-sorter-utils'
-
+import { sortingFns } from '@tanstack/react-table'
 import type { FilterFn, FilterMeta, SortingFn } from '@tanstack/react-table'
 
 // カスタムのファジーフィルタ関数を定義（match-sorter utilsを使って行にランキング情報を適用）
@@ -21,12 +20,8 @@ export const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
 export const fuzzySort: SortingFn<any> = (rowA, rowB, columnId) => {
   let dir = 0
 
-  const columnFilterMetaA = rowA.columnFiltersMeta[columnId] as
-    | FilterMeta
-    | undefined
-  const columnFilterMetaB = rowB.columnFiltersMeta[columnId] as
-    | FilterMeta
-    | undefined
+  const columnFilterMetaA = rowA.columnFiltersMeta[columnId] as FilterMeta | undefined
+  const columnFilterMetaB = rowB.columnFiltersMeta[columnId] as FilterMeta | undefined
 
   // 列にランキング情報がある場合のみランクでソート
   if (columnFilterMetaA && columnFilterMetaB) {

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -1,5 +1,5 @@
-import type { FilterFn, RowData } from '@tanstack/react-table'
 import type { RankingInfo } from '@tanstack/match-sorter-utils'
+import type { FilterFn, RowData } from '@tanstack/react-table'
 
 declare module '@tanstack/react-table' {
   /**

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
+
 import { theme as themeApi } from '@/api'
 
 type Theme = 'dark' | 'light' | 'system'
@@ -52,8 +53,7 @@ export function ThemeProvider({
     root.classList.remove('light', 'dark')
 
     if (theme === 'system') {
-      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
-        .matches
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
         ? 'dark'
         : 'light'
 
@@ -86,12 +86,9 @@ export function ThemeProvider({
 }
 
 export const useTheme = () => {
-  const context = useContext(ThemeProviderContext) as
-    | ThemeProviderState
-    | undefined
+  const context = useContext(ThemeProviderContext) as ThemeProviderState | undefined
 
-  if (context === undefined)
-    throw new Error('useTheme must be used within a ThemeProvider')
+  if (context === undefined) throw new Error('useTheme must be used within a ThemeProvider')
 
   return context
 }

--- a/src/components/theme-switcher.tsx
+++ b/src/components/theme-switcher.tsx
@@ -1,7 +1,7 @@
 import { LaptopIcon, MoonIcon, SunIcon } from 'lucide-react'
 
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { useTheme } from '@/components/theme-provider'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 
 export function ThemeSwitcher({ className }: { className?: string }) {
   const { theme, setTheme } = useTheme()

--- a/src/data/demo-table-data.ts
+++ b/src/data/demo-table-data.ts
@@ -27,11 +27,7 @@ const newPerson = (num: number): Person => {
     age: faker.number.int(40),
     visits: faker.number.int(1000),
     progress: faker.number.int(100),
-    status: faker.helpers.shuffle<Person['status']>([
-      'relationship',
-      'complicated',
-      'single',
-    ])[0],
+    status: faker.helpers.shuffle<Person['status']>(['relationship', 'complicated', 'single'])[0],
   }
 }
 

--- a/src/features/auth/api/auth.tsx
+++ b/src/features/auth/api/auth.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { auth as authApi } from '@/api'
 
 export type AuthUser = {
@@ -50,13 +51,10 @@ export function AuthProvider(props: { children: React.ReactNode }) {
     }
   }, [])
 
-  const login = React.useCallback(
-    async (username: string, password: string) => {
-      const status = await authApi.login(username, password)
-      setUser(status.user)
-    },
-    [],
-  )
+  const login = React.useCallback(async (username: string, password: string) => {
+    const status = await authApi.login(username, password)
+    setUser(status.user)
+  }, [])
 
   const logout = React.useCallback(() => {
     void authApi.logout()
@@ -80,9 +78,7 @@ export function AuthProvider(props: { children: React.ReactNode }) {
     )
   }
 
-  return (
-    <AuthContext.Provider value={{ auth }}>{children}</AuthContext.Provider>
-  )
+  return <AuthContext.Provider value={{ auth }}>{children}</AuthContext.Provider>
 }
 
 export function useAuth() {

--- a/src/features/chat/components/chat-session-provider.tsx
+++ b/src/features/chat/components/chat-session-provider.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
-import { useChat } from '@tanstack/ai-react'
-import { clientTools } from '@tanstack/ai-client'
 
-import { clockTool } from '../api/tools/tools'
+import { clientTools } from '@tanstack/ai-client'
+import type { UIMessage } from '@tanstack/ai-client'
+import { useChat } from '@tanstack/ai-react'
 
 import type { Model } from '#/main/features/chat/ollama/models'
-import type { UIMessage } from '@tanstack/ai-client'
-
-import { fetchIpcEvents } from '@/lib/fetchIpcEvents'
 import { mcp } from '@/api'
+import { fetchIpcEvents } from '@/lib/fetchIpcEvents'
+
+import { clockTool } from '../api/tools/tools'
 
 type ChatSessionValue = {
   input: string
@@ -64,28 +64,15 @@ export function ChatSessionProvider(props: ChatSessionProviderProps) {
       stop: chat.stop,
       status: chat.status,
     }
-  }, [
-    chat.isLoading,
-    chat.messages,
-    chat.sendMessage,
-    chat.status,
-    chat.stop,
-    input,
-  ])
+  }, [chat.isLoading, chat.messages, chat.sendMessage, chat.status, chat.stop, input])
 
-  return (
-    <ChatSessionContext.Provider value={value}>
-      {children}
-    </ChatSessionContext.Provider>
-  )
+  return <ChatSessionContext.Provider value={value}>{children}</ChatSessionContext.Provider>
 }
 
 export function useChatSession() {
   const ctx = React.useContext(ChatSessionContext)
   if (!ctx) {
-    throw new Error(
-      'useChatSession must be used within <ChatSessionProvider />',
-    )
+    throw new Error('useChatSession must be used within <ChatSessionProvider />')
   }
   return ctx
 }

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -1,15 +1,14 @@
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
-import { ArrowUpIcon, BotIcon, SquareIcon, User2Icon } from 'lucide-react'
 
-import { useChatSession } from '@/features/chat/components/chat-session-provider'
+import { ArrowUpIcon, BotIcon, SquareIcon, User2Icon } from 'lucide-react'
+import remarkGfm from 'remark-gfm'
+
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion'
-import { Separator } from '@/components/ui/separator'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,7 +20,6 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
-import { useAuth } from '@/features/auth/api/auth'
 import { Field } from '@/components/ui/field'
 import {
   InputGroup,
@@ -29,6 +27,9 @@ import {
   InputGroupButton,
   InputGroupTextarea,
 } from '@/components/ui/input-group'
+import { Separator } from '@/components/ui/separator'
+import { useAuth } from '@/features/auth/api/auth'
+import { useChatSession } from '@/features/chat/components/chat-session-provider'
 import { useAutoScrollToBottom } from '@/hooks/use-auto-scroll-to-bottom'
 
 export function Chat() {
@@ -37,11 +38,9 @@ export function Chat() {
   } = useAuth()
   const username = user?.username || 'あなた'
 
-  const { input, setInput, messages, sendMessage, isLoading, stop, status } =
-    useChatSession()
+  const { input, setInput, messages, sendMessage, isLoading, stop, status } = useChatSession()
 
-  const { scrollContainerRef, scrollBottomRef, onScroll } =
-    useAutoScrollToBottom([messages])
+  const { scrollContainerRef, scrollBottomRef, onScroll } = useAutoScrollToBottom([messages])
 
   const send = () => {
     if (isLoading) {
@@ -80,10 +79,7 @@ export function Chat() {
         className="min-h-0 flex-1 overflow-y-auto flex flex-col gap-4"
       >
         {messages.map((msg) => (
-          <div
-            key={msg.id}
-            className="border border-border rounded bg-background text-foreground"
-          >
+          <div key={msg.id} className="border border-border rounded bg-background text-foreground">
             <div className="p-2">
               {msg.role === 'assistant' ? (
                 <div className="flex items-end gap-1">
@@ -123,9 +119,7 @@ export function Chat() {
                       >
                         <AccordionItem value={key}>
                           <AccordionTrigger>Thinking</AccordionTrigger>
-                          <AccordionContent className="h-fit">
-                            {part.content}
-                          </AccordionContent>
+                          <AccordionContent className="h-fit">{part.content}</AccordionContent>
                         </AccordionItem>
                       </Accordion>
                     )
@@ -138,9 +132,7 @@ export function Chat() {
                         key={key}
                       >
                         <AccordionItem value={key}>
-                          <AccordionTrigger>
-                            Tool Call: {part.name}
-                          </AccordionTrigger>
+                          <AccordionTrigger>Tool Call: {part.name}</AccordionTrigger>
                           <AccordionContent>
                             <pre className="font-mono not-italic">
                               {JSON.stringify(part, null, 2)}
@@ -176,11 +168,7 @@ export function Chat() {
                   case 'video':
                     return <div key={key}>Not Implemented</div>
                   default:
-                    return (
-                      <div key={key}>
-                        Unknown part type: {(part as any).type}
-                      </div>
-                    )
+                    return <div key={key}>Unknown part type: {(part as any).type}</div>
                 }
               })}
             </div>
@@ -217,11 +205,7 @@ export function Chat() {
                 className="ml-auto"
                 disabled={disabled}
               >
-                {isLoading ? (
-                  <SquareIcon className="fill-primary-foreground" />
-                ) : (
-                  <ArrowUpIcon />
-                )}
+                {isLoading ? <SquareIcon className="fill-primary-foreground" /> : <ArrowUpIcon />}
               </InputGroupButton>
             </InputGroupAddon>
           </InputGroup>
@@ -236,15 +220,9 @@ function TextContent({ content }: { content: string }) {
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       components={{
-        h1: (props) => (
-          <h1 className="text-2xl font-bold mt-6 mb-3" {...props} />
-        ),
-        h2: (props) => (
-          <h2 className="text-xl font-bold mt-5 mb-2" {...props} />
-        ),
-        h3: (props) => (
-          <h3 className="text-lg font-semibold mt-4 mb-2" {...props} />
-        ),
+        h1: (props) => <h1 className="text-2xl font-bold mt-6 mb-3" {...props} />,
+        h2: (props) => <h2 className="text-xl font-bold mt-5 mb-2" {...props} />,
+        h3: (props) => <h3 className="text-lg font-semibold mt-4 mb-2" {...props} />,
 
         p: (props) => <p className="my-3 leading-7" {...props} />,
         ul: (props) => <ul className="list-disc pl-6 my-3" {...props} />,
@@ -256,10 +234,7 @@ function TextContent({ content }: { content: string }) {
 
           if (!safeHref) {
             return (
-              <span
-                className="underline underline-offset-4 text-muted-foreground"
-                {...props}
-              />
+              <span className="underline underline-offset-4 text-muted-foreground" {...props} />
             )
           }
 
@@ -270,9 +245,7 @@ function TextContent({ content }: { content: string }) {
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>
-                    外部リンクにアクセスしようとしています
-                  </AlertDialogTitle>
+                  <AlertDialogTitle>外部リンクにアクセスしようとしています</AlertDialogTitle>
                   <AlertDialogDescription className="overflow-auto">
                     本当にアクセスしますか？
                     <br />
@@ -303,27 +276,15 @@ function TextContent({ content }: { content: string }) {
               </code>
             )
           return (
-            <code
-              className="px-1 py-0.5 rounded bg-black/5 font-mono text-[0.9em]"
-              {...props}
-            >
+            <code className="px-1 py-0.5 rounded bg-black/5 font-mono text-[0.9em]" {...props}>
               {children}
             </code>
           )
         },
-        pre: (props) => (
-          <pre
-            className="my-4 p-3 rounded overflow-x-auto bg-black/5"
-            {...props}
-          />
-        ),
+        pre: (props) => <pre className="my-4 p-3 rounded overflow-x-auto bg-black/5" {...props} />,
 
-        table: (props) => (
-          <table className="my-4 w-full border-collapse" {...props} />
-        ),
-        th: (props) => (
-          <th className="border px-2 py-1 text-left bg-black/5" {...props} />
-        ),
+        table: (props) => <table className="my-4 w-full border-collapse" {...props} />,
+        th: (props) => <th className="border px-2 py-1 text-left bg-black/5" {...props} />,
         td: (props) => <td className="border px-2 py-1 align-top" {...props} />,
       }}
     >

--- a/src/features/chat/components/open-chat.tsx
+++ b/src/features/chat/components/open-chat.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react'
+
 import { BotIcon, XIcon } from 'lucide-react'
+
 import type { Model } from '#/main/features/chat/ollama/models'
 import { MODELS, modelSchema } from '#/main/features/chat/ollama/models'
-import {
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from '@/components/ui/sidebar'
+import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogClose,
@@ -23,13 +21,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
 import { Chat } from '@/features/chat/components/chat'
 import { ChatSessionProvider } from '@/features/chat/components/chat-session-provider'
-import { Button } from '@/components/ui/button'
 
 export function OpenChat() {
-  const [selectedModel, setSelectedModel] =
-    React.useState<Model>('gpt-oss:20b-cloud')
+  const [selectedModel, setSelectedModel] = React.useState<Model>('gpt-oss:20b-cloud')
 
   return (
     <SidebarMenu>
@@ -64,9 +61,7 @@ export function OpenChat() {
                   </div>
                   <div className="flex items-center justify-end  gap-1">
                     <Select
-                      onValueChange={(value) =>
-                        setSelectedModel(modelSchema.parse(value))
-                      }
+                      onValueChange={(value) => setSelectedModel(modelSchema.parse(value))}
                       value={selectedModel}
                     >
                       <SelectTrigger>
@@ -83,11 +78,7 @@ export function OpenChat() {
                       </SelectContent>
                     </Select>
                     <DialogClose asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="hover:text-destructive"
-                      >
+                      <Button variant="ghost" size="sm" className="hover:text-destructive">
                         <XIcon />
                       </Button>
                     </DialogClose>

--- a/src/features/style/components/design-provider.tsx
+++ b/src/features/style/components/design-provider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+
 import { StyleProvider } from './style-provider'
 import { ThemeProvider } from './theme-provider'
 

--- a/src/features/style/components/style-provider.tsx
+++ b/src/features/style/components/style-provider.tsx
@@ -10,9 +10,7 @@ type StyleProviderState = {
   setStyle: (style: Style) => void
 }
 
-export const StyleProviderContext = createContext<StyleProviderState>(
-  {} as StyleProviderState,
-)
+export const StyleProviderContext = createContext<StyleProviderState>({} as StyleProviderState)
 
 export type StyleProviderProps = {
   children: ReactNode
@@ -21,11 +19,7 @@ export type StyleProviderProps = {
 }
 
 export function StyleProvider(props: StyleProviderProps) {
-  const {
-    children,
-    defaultStyle = 'vega',
-    storageKey = 'vite-ui-style',
-  } = props
+  const { children, defaultStyle = 'vega', storageKey = 'vite-ui-style' } = props
 
   const root = window.document.documentElement
 
@@ -45,11 +39,7 @@ export function StyleProvider(props: StyleProviderProps) {
     },
   }
 
-  return (
-    <StyleProviderContext.Provider value={value}>
-      {children}
-    </StyleProviderContext.Provider>
-  )
+  return <StyleProviderContext.Provider value={value}>{children}</StyleProviderContext.Provider>
 }
 
 /**

--- a/src/features/style/components/style-switcher.tsx
+++ b/src/features/style/components/style-switcher.tsx
@@ -1,8 +1,9 @@
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { formatKebabAsTitle } from '@/lib/format-kebab-as-title'
+
 import { useStyle } from '../api/use-style'
 import { STYLES } from './style-provider'
 import type { Style } from './style-provider'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
-import { formatKebabAsTitle } from '@/lib/format-kebab-as-title'
 
 export function StyleSwitcher({ className }: { className?: string }) {
   const { style, setStyle } = useStyle()

--- a/src/features/style/components/theme-provider.tsx
+++ b/src/features/style/components/theme-provider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+
 import { THEMES } from './themes'
 
 export type Theme = (typeof THEMES)[number]['name']
@@ -19,11 +20,7 @@ export type ThemeProviderProps = {
 }
 
 export function ThemeProvider(props: ThemeProviderProps) {
-  const {
-    children,
-    defaultTheme = 'teal',
-    storageKey = 'vite-ui-design-theme',
-  } = props
+  const { children, defaultTheme = 'teal', storageKey = 'vite-ui-design-theme' } = props
 
   const [theme, setTheme] = React.useState<Theme>(() => {
     const storedTheme = localStorage.getItem(storageKey)
@@ -46,11 +43,7 @@ export function ThemeProvider(props: ThemeProviderProps) {
     },
   }
 
-  return (
-    <ThemeProviderContext.Provider value={value}>
-      {children}
-    </ThemeProviderContext.Provider>
-  )
+  return <ThemeProviderContext.Provider value={value}>{children}</ThemeProviderContext.Provider>
 }
 
 /**
@@ -62,11 +55,7 @@ export function applyTheme(document: Document, theme: Theme) {
     return
   }
 
-  const {
-    theme: themeVars,
-    light: lightVars,
-    dark: darkVars,
-  } = themeObj.cssVars
+  const { theme: themeVars, light: lightVars, dark: darkVars } = themeObj.cssVars
 
   let cssText = ':root {\n'
   if (themeVars) {

--- a/src/features/style/components/theme-switcher.tsx
+++ b/src/features/style/components/theme-switcher.tsx
@@ -1,7 +1,8 @@
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { cn } from '@/lib/utils'
+
 import { useTheme } from '../api/use-theme'
 import { THEMES } from './themes'
-import { cn } from '@/lib/utils'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 
 export function ThemeSwitcher({ className }: { className?: string }) {
   const { theme, setTheme } = useTheme()

--- a/src/hooks/use-auto-scroll-to-bottom.ts
+++ b/src/hooks/use-auto-scroll-to-bottom.ts
@@ -7,10 +7,7 @@ type Options = {
   behavior?: ScrollBehavior
 }
 
-export function useAutoScrollToBottom(
-  deps: ReadonlyArray<unknown>,
-  options: Options = {},
-) {
+export function useAutoScrollToBottom(deps: ReadonlyArray<unknown>, options: Options = {}) {
   const {
     enabled = true,
     bottomThreshold = 48,
@@ -28,9 +25,7 @@ export function useAutoScrollToBottom(
     if (!enabled) return
     if (!isPinnedToBottomRef.current) return
 
-    const nextBehavior = hasAutoScrolledOnceRef.current
-      ? behavior
-      : initialBehavior
+    const nextBehavior = hasAutoScrolledOnceRef.current ? behavior : initialBehavior
 
     hasAutoScrolledOnceRef.current = true
 

--- a/src/hooks/use-iframe-message.ts
+++ b/src/hooks/use-iframe-message.ts
@@ -6,19 +6,15 @@ import * as React from 'react'
  * iframe が読み込まれた後に `sendToIframe` を使ってメッセージを送信できます。
  * また、iframe からメッセージを受信したい場合は `onMessage` コールバックを指定します。
  */
-export function useIframeMessage<T>(
-  onMessage?: (window: Window, data: T) => void,
-): {
+export function useIframeMessage<T>(onMessage?: (window: Window, data: T) => void): {
   sendToIframe: (data: T) => void
   ref: React.RefObject<HTMLIFrameElement | null>
 } {
   const ref = React.useRef<HTMLIFrameElement | null>(null)
 
-  const [sendToIframe, setSendToIframe] = React.useState<(data: T) => void>(
-    () => () => {
-      console.log('iframe is not ready yet')
-    },
-  )
+  const [sendToIframe, setSendToIframe] = React.useState<(data: T) => void>(() => () => {
+    console.log('iframe is not ready yet')
+  })
 
   React.useEffect(() => {
     const iframe = ref.current

--- a/src/integrations/tanstack-query/root-provider.tsx
+++ b/src/integrations/tanstack-query/root-provider.tsx
@@ -15,7 +15,5 @@ export function Provider({
   children: React.ReactNode
   queryClient: QueryClient
 }) {
-  return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  )
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 }

--- a/src/lib/fetchIpcEvents.ts
+++ b/src/lib/fetchIpcEvents.ts
@@ -39,8 +39,7 @@ export function fetchIpcEvents() {
       if (abortSignal) {
         const onAbort = () => queue.close()
         abortSignal.addEventListener('abort', onAbort, { once: true })
-        removeAbortListener = () =>
-          abortSignal.removeEventListener('abort', onAbort)
+        removeAbortListener = () => abortSignal.removeEventListener('abort', onAbort)
       }
 
       try {
@@ -57,10 +56,7 @@ export function fetchIpcEvents() {
           }
         }
       } catch (err) {
-        console.error(
-          `${new Date().toISOString()} Error in fetchIpcEvents connection:`,
-          err,
-        )
+        console.error(`${new Date().toISOString()} Error in fetchIpcEvents connection:`, err)
         throw err
       } finally {
         removeListener()

--- a/src/lib/frame-rpc.ts
+++ b/src/lib/frame-rpc.ts
@@ -40,16 +40,12 @@ function randomId(): string {
   }
 }
 
-export function requestAuthStatusFromParent<T>(options?: {
-  timeoutMs?: number
-}): Promise<T> {
+export function requestAuthStatusFromParent<T>(options?: { timeoutMs?: number }): Promise<T> {
   const timeoutMs = options?.timeoutMs ?? 2000
 
   if (window.self === window.top) {
     return Promise.reject(
-      new Error(
-        '[auth-status-rpc] requestAuthStatusFromParent must be called from an iframe',
-      ),
+      new Error('[auth-status-rpc] requestAuthStatusFromParent must be called from an iframe'),
     )
   }
 
@@ -60,8 +56,7 @@ export function requestAuthStatusFromParent<T>(options?: {
     id,
   }
 
-  const targetOrigin =
-    window.location.origin === 'null' ? '*' : window.location.origin
+  const targetOrigin = window.location.origin === 'null' ? '*' : window.location.origin
 
   return new Promise<T>((resolve, reject) => {
     const timeout = window.setTimeout(() => {
@@ -82,18 +77,12 @@ export function requestAuthStatusFromParent<T>(options?: {
       cleanup()
 
       if (maybe.ok === true) {
-        resolve(
-          (maybe as Extract<AuthStatusRpcResponse, { ok: true }>).result as T,
-        )
+        resolve((maybe as Extract<AuthStatusRpcResponse, { ok: true }>).result as T)
         return
       }
 
       if (maybe.ok === false) {
-        reject(
-          new Error(
-            (maybe as Extract<AuthStatusRpcResponse, { ok: false }>).error,
-          ),
-        )
+        reject(new Error((maybe as Extract<AuthStatusRpcResponse, { ok: false }>).error))
         return
       }
 
@@ -116,9 +105,7 @@ export function requestAuthStatusFromParent<T>(options?: {
   })
 }
 
-export function registerAuthStatusResponder(
-  handler: () => unknown | Promise<unknown>,
-): () => void {
+export function registerAuthStatusResponder(handler: () => unknown | Promise<unknown>): () => void {
   function onMessage(event: MessageEvent) {
     const data = event.data as unknown
     if (!isSameOrigin(event.origin)) return

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -39,18 +39,12 @@ export function getPaginationItems({
   const endBoundaryStart = Math.max(totalPages - safeBoundaryCount, 0)
 
   const siblingsStart = Math.max(
-    Math.min(
-      clampedPageIndex - safeSiblingCount,
-      endBoundaryStart - safeSiblingCount * 2 - 1,
-    ),
+    Math.min(clampedPageIndex - safeSiblingCount, endBoundaryStart - safeSiblingCount * 2 - 1),
     startBoundaryEnd,
   )
 
   const siblingsEnd = Math.min(
-    Math.max(
-      clampedPageIndex + safeSiblingCount,
-      startBoundaryEnd + safeSiblingCount * 2,
-    ),
+    Math.max(clampedPageIndex + safeSiblingCount, startBoundaryEnd + safeSiblingCount * 2),
     endBoundaryStart - 1,
   )
 
@@ -78,11 +72,7 @@ export function getPaginationItems({
   }
 
   // 末尾の境界ページ
-  for (
-    let i = Math.max(endBoundaryStart, safeBoundaryCount);
-    i < totalPages;
-    i++
-  ) {
+  for (let i = Math.max(endBoundaryStart, safeBoundaryCount); i < totalPages; i++) {
     tokens.push(i)
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,20 +1,17 @@
 import { StrictMode, useEffect, useRef } from 'react'
-import ReactDOM from 'react-dom/client'
-import {
-  RouterProvider,
-  createHashHistory,
-  createRouter,
-} from '@tanstack/react-router'
 
-import * as TanStackQueryProvider from './integrations/tanstack-query/root-provider.tsx'
-import { routeTree } from './routeTree.gen'
-import reportWebVitals from './reportWebVitals.ts'
-import { ThemeProvider } from '@/components/theme-provider'
+import { RouterProvider, createHashHistory, createRouter } from '@tanstack/react-router'
+import ReactDOM from 'react-dom/client'
+
 import { DevToolsProvider } from '@/components/devtools-provider.tsx'
+import { ThemeProvider } from '@/components/theme-provider'
+import { Toaster } from '@/components/ui/sonner'
 import { AuthProvider, useAuth } from '@/features/auth/api/auth'
 import { DesignProvider } from '@/features/style/components/design-provider'
-import { Toaster } from '@/components/ui/sonner'
 
+import * as TanStackQueryProvider from './integrations/tanstack-query/root-provider.tsx'
+import reportWebVitals from './reportWebVitals.ts'
+import { routeTree } from './routeTree.gen'
 // 生成されたルートツリーをインポート
 
 import './styles.css'
@@ -63,10 +60,7 @@ if (rootElement && !rootElement.innerHTML) {
 
       // TanStack Router はマッチやローダーをキャッシュします。認証状態が変わったとき、
       // 次のナビゲーションでガードを再評価するために強制的にキャッシュを無効化します。
-      if (
-        wasAuthenticated !== null &&
-        wasAuthenticated !== auth.isAuthenticated
-      ) {
+      if (wasAuthenticated !== null && wasAuthenticated !== auth.isAuthenticated) {
         router.invalidate()
       }
     }, [auth.isAuthenticated])

--- a/src/routes/(app)/demo.fs.tsx
+++ b/src/routes/(app)/demo.fs.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+
 import { useMutation, useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+
 import { fs } from '@/api'
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
@@ -196,18 +198,14 @@ function ShowOpenFileDialogAndReadAsTextRow() {
             {content && (
               <div>
                 <h3 className="text-sm font-bold">ファイル内容:</h3>
-                <pre className="max-h-[200px] overflow-auto border">
-                  {content}
-                </pre>
+                <pre className="max-h-[200px] overflow-auto border">{content}</pre>
               </div>
             )}
           </>
         ) : isError ? (
           <span className="text-red-500">エラーが発生しました</span>
         ) : isErrorOpenFile ? (
-          <span className="text-red-500">
-            ファイル読み込み中にエラーが発生しました
-          </span>
+          <span className="text-red-500">ファイル読み込み中にエラーが発生しました</span>
         ) : null}
       </td>
     </tr>
@@ -453,13 +451,9 @@ function ShowSaveDialogAndWriteAsTextRow() {
                 <h3 className="text-sm font-bold">選択されたファイル:</h3>
                 <pre>{file}</pre>
                 {isWriteSuccess ? (
-                  <span className="text-green-500">
-                    テキストが正常に書き込まれました
-                  </span>
+                  <span className="text-green-500">テキストが正常に書き込まれました</span>
                 ) : (
-                  <span className="text-red-500">
-                    テキストの書き込みに失敗しました
-                  </span>
+                  <span className="text-red-500">テキストの書き込みに失敗しました</span>
                 )}
               </div>
             )}
@@ -467,9 +461,7 @@ function ShowSaveDialogAndWriteAsTextRow() {
         ) : isError ? (
           <span className="text-red-500">ダイアログが開かれませんでした</span>
         ) : isWriteError ? (
-          <span className="text-red-500">
-            ファイル書き込み中にエラーが発生しました
-          </span>
+          <span className="text-red-500">ファイル書き込み中にエラーが発生しました</span>
         ) : null}
       </td>
     </tr>
@@ -562,13 +554,9 @@ function ShowSaveDialogAndWriteAsArrayBufferRow() {
                 <h3 className="text-sm font-bold">選択されたファイル:</h3>
                 <pre>{file}</pre>
                 {isWriteSuccess ? (
-                  <span className="text-green-500">
-                    バイナリデータが正常に書き込まれました
-                  </span>
+                  <span className="text-green-500">バイナリデータが正常に書き込まれました</span>
                 ) : (
-                  <span className="text-red-500">
-                    バイナリデータの書き込みに失敗しました
-                  </span>
+                  <span className="text-red-500">バイナリデータの書き込みに失敗しました</span>
                 )}
               </div>
             )}
@@ -576,9 +564,7 @@ function ShowSaveDialogAndWriteAsArrayBufferRow() {
         ) : isError ? (
           <span className="text-red-500">ダイアログが開かれませんでした</span>
         ) : isWriteError ? (
-          <span className="text-red-500">
-            ファイル書き込み中にエラーが発生しました
-          </span>
+          <span className="text-red-500">ファイル書き込み中にエラーが発生しました</span>
         ) : null}
       </td>
     </tr>
@@ -660,9 +646,7 @@ function ShowOpenFolderDialogAndReadDirectoryRow() {
   })
   const [folder, setFolder] = React.useState<string>('')
 
-  const [entries, setEntries] = React.useState<
-    Awaited<ReturnType<typeof fs.readDirectory>>
-  >([])
+  const [entries, setEntries] = React.useState<Awaited<ReturnType<typeof fs.readDirectory>>>([])
   const {
     mutate: readDirectory,
     isSuccess: isReadSuccess,
@@ -736,16 +720,12 @@ function ShowOpenFolderDialogAndReadDirectoryRow() {
             </ul>
             <h3 className="text-sm font-bold">フォルダ内容:</h3>
             <FolderTree folder={folder} />
-            {entries.length === 0 && (
-              <span className="text-gray-500">フォルダは空です</span>
-            )}
+            {entries.length === 0 && <span className="text-gray-500">フォルダは空です</span>}
           </>
         ) : isError ? (
           <span className="text-red-500">エラーが発生しました</span>
         ) : isReadError ? (
-          <span className="text-red-500">
-            フォルダ読み込み中にエラーが発生しました
-          </span>
+          <span className="text-red-500">フォルダ読み込み中にエラーが発生しました</span>
         ) : null}
       </td>
     </tr>
@@ -804,11 +784,7 @@ function GetPathForFileRow() {
 
         <div>
           <h3 className="text-sm font-bold">取得したパス:</h3>
-          {path ? (
-            <pre className="text-[10px]">{path}</pre>
-          ) : (
-            <span>パスが取得されていません</span>
-          )}
+          {path ? <pre className="text-[10px]">{path}</pre> : <span>パスが取得されていません</span>}
         </div>
       </td>
     </tr>
@@ -828,11 +804,7 @@ function ImageFromArrayBuffer({ arrayBuffer }: { arrayBuffer: ArrayBuffer }) {
 
   if (!src) return <span>画像を生成中...</span>
   return (
-    <img
-      src={src}
-      alt="Selected File"
-      className="max-h-[400px] max-w-full object-contain border"
-    />
+    <img src={src} alt="Selected File" className="max-h-[400px] max-w-full object-contain border" />
   )
 }
 
@@ -863,9 +835,7 @@ function FolderTree({
 
   React.useEffect(() => {
     if (data) {
-      const buildTree = (
-        entries: Array<DirectoryEntry>,
-      ): Array<DirectoryEntryEx> => {
+      const buildTree = (entries: Array<DirectoryEntry>): Array<DirectoryEntryEx> => {
         return entries.map((entry) => ({
           ...entry,
           isOpen: false,
@@ -880,9 +850,7 @@ function FolderTree({
     switch (entry.type) {
       case 'directory':
         setTree((prev) =>
-          prev.map((e) =>
-            e.path === entry.path ? { ...e, isOpen: !e.isOpen } : e,
-          ),
+          prev.map((e) => (e.path === entry.path ? { ...e, isOpen: !e.isOpen } : e)),
         )
         break
       case 'file':
@@ -951,11 +919,7 @@ function FolderTree({
 
             {/* サブフォルダの表示 */}
             {entry.isOpen ? (
-              <FolderTree
-                folder={entry.path}
-                depth={depth + 1}
-                onSelectFile={onSelectFile}
-              />
+              <FolderTree folder={entry.path} depth={depth + 1} onSelectFile={onSelectFile} />
             ) : null}
           </li>
         ))
@@ -1126,10 +1090,7 @@ function FileDetails({ filePath }: { filePath: string }) {
         デフォルトアプリで開く
       </button>
       <div className="mt-2"></div>
-      <RadioGroup
-        defaultValue={displayMode}
-        onValueChange={handleChangeDisplayMode}
-      >
+      <RadioGroup defaultValue={displayMode} onValueChange={handleChangeDisplayMode}>
         <div className="flex items-center space-x-2">
           <RadioGroupItem value="text" id="open-as-text" />
           <Label htmlFor="open-as-text" className="text-xs">
@@ -1190,9 +1151,7 @@ function FileDetails({ filePath }: { filePath: string }) {
             {textContent && (
               <div className="mt-2">
                 <h4 className="text-sm font-bold">ファイル内容:</h4>
-                <pre className="max-h-[200px] overflow-auto border p-2">
-                  {textContent}
-                </pre>
+                <pre className="max-h-[200px] overflow-auto border p-2">{textContent}</pre>
               </div>
             )}
           </>

--- a/src/routes/(app)/demo.index.tsx
+++ b/src/routes/(app)/demo.index.tsx
@@ -108,9 +108,7 @@ function RouteComponent() {
                 <CardDescription>{kpi.hint}</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-semibold tabular-nums">
-                  {kpi.value}
-                </div>
+                <div className="text-2xl font-semibold tabular-nums">{kpi.value}</div>
               </CardContent>
             </Card>
           ))}
@@ -139,9 +137,7 @@ function RouteComponent() {
                       <TableCell className="font-medium">{a.name}</TableCell>
                       <TableCell>{a.type}</TableCell>
                       <TableCell>{statusBadge(a.status)}</TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {a.at}
-                      </TableCell>
+                      <TableCell className="text-muted-foreground">{a.at}</TableCell>
                       <TableCell>
                         <Button variant="ghost" size="sm" asChild>
                           <Link to={a.to}>開く</Link>
@@ -160,25 +156,13 @@ function RouteComponent() {
               <CardDescription>よく触るデモへの導線</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              <Button
-                className="w-full justify-start"
-                variant="outline"
-                asChild
-              >
+              <Button className="w-full justify-start" variant="outline" asChild>
                 <Link to="/demo/kakeibo">家計簿</Link>
               </Button>
-              <Button
-                className="w-full justify-start"
-                variant="outline"
-                asChild
-              >
+              <Button className="w-full justify-start" variant="outline" asChild>
                 <Link to="/demo/table">テーブル</Link>
               </Button>
-              <Button
-                className="w-full justify-start"
-                variant="outline"
-                asChild
-              >
+              <Button className="w-full justify-start" variant="outline" asChild>
                 <Link to="/demo/web">Web Events</Link>
               </Button>
             </CardContent>

--- a/src/routes/(app)/demo.kakeibo.tsx
+++ b/src/routes/(app)/demo.kakeibo.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+
 import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -12,12 +13,13 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { Square, Table } from 'lucide-react'
 import type { Table as TanStackTable } from '@tanstack/react-table'
+import { Square, Table } from 'lucide-react'
+
+import { kakeibo } from '@/api'
 import { BasicTable } from '@/components/table/basic-table'
 import { fuzzyFilter } from '@/components/table/tableUtils'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { kakeibo } from '@/api'
 
 export type Entry = Awaited<ReturnType<typeof kakeibo.entries>>[number]
 
@@ -146,10 +148,7 @@ function View(props: { data: Array<Entry>; refreshData?: () => void }) {
   )
 }
 
-function TableView(props: {
-  table: TanStackTable<Entry>
-  refreshData?: () => void
-}) {
+function TableView(props: { table: TanStackTable<Entry>; refreshData?: () => void }) {
   'use no memo'
 
   const { table, refreshData } = props
@@ -176,9 +175,7 @@ function Card(props: { entry: Entry }) {
     <div className="border rounded-lg p-4 bg-gray-50 hover:bg-gray-100 transition">
       <div className="flex justify-between items-center mb-2">
         <span className="text-gray-600 text-sm">{entry.spent_at}</span>
-        <span className="text-lg font-bold text-green-700">
-          ¥{entry.amount.toLocaleString()}
-        </span>
+        <span className="text-lg font-bold text-green-700">¥{entry.amount.toLocaleString()}</span>
       </div>
       <div className="text-gray-700 text-sm">
         <span className="mr-4">
@@ -188,8 +185,7 @@ function Card(props: { entry: Entry }) {
           カテゴリ: <span className="font-medium">{entry.category}</span>
         </span>
         <span>
-          支払い方法:{' '}
-          <span className="font-medium">{entry.payment_method}</span>
+          支払い方法: <span className="font-medium">{entry.payment_method}</span>
         </span>
       </div>
     </div>

--- a/src/routes/(app)/demo.table.tsx
+++ b/src/routes/(app)/demo.table.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { createFileRoute } from '@tanstack/react-router'
 import {
   createColumnHelper,
@@ -8,12 +9,12 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-
 import type { ColumnFiltersState } from '@tanstack/react-table'
-import type { Person } from '@/data/demo-table-data'
-import { makeData } from '@/data/demo-table-data'
+
 import { BasicTable } from '@/components/table/basic-table'
 import { fuzzyFilter, fuzzySort } from '@/components/table/tableUtils'
+import type { Person } from '@/data/demo-table-data'
+import { makeData } from '@/data/demo-table-data'
 
 export const Route = createFileRoute('/(app)/demo/table')({
   component: TableDemo,
@@ -29,9 +30,7 @@ function PersonTable() {
 
   const rerender = React.useReducer(() => ({}), {})[1]
 
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    [],
-  )
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
   const [globalFilter, setGlobalFilter] = React.useState('')
 
   const columns = React.useMemo(() => {
@@ -96,7 +95,5 @@ function PersonTable() {
     }
   }, [table.getState().columnFilters[0]?.id])
 
-  return (
-    <BasicTable table={table} rerender={rerender} refreshData={refreshData} />
-  )
+  return <BasicTable table={table} rerender={rerender} refreshData={refreshData} />
 }

--- a/src/routes/(app)/demo.tanstack-query.tsx
+++ b/src/routes/(app)/demo.tanstack-query.tsx
@@ -1,5 +1,5 @@
-import { createFileRoute } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/(app)/demo/tanstack-query')({
   component: TanStackQueryDemo,
@@ -27,9 +27,7 @@ function TanStackQueryDemo() {
       }}
     >
       <div className="w-full max-w-2xl p-8 rounded-xl backdrop-blur-md bg-black/50 shadow-xl border-8 border-black/10">
-        <h1 className="text-2xl mb-4">
-          TanStack Query Simple Promise Handling
-        </h1>
+        <h1 className="text-2xl mb-4">TanStack Query Simple Promise Handling</h1>
         <ul className="mb-4 space-y-2">
           {data.map((todo) => (
             <li

--- a/src/routes/(app)/demo.web.tsx
+++ b/src/routes/(app)/demo.web.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { createFileRoute } from '@tanstack/react-router'
-import { web } from '@/api'
 
+import { createFileRoute } from '@tanstack/react-router'
+
+import { web } from '@/api'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -74,9 +75,7 @@ function RouteComponent() {
     <ContextMenuWrapper>
       <div className="p-4">
         <h1 className="text-2xl font-bold mb-4">Web Events Demo</h1>
-        <p className="mb-4">
-          This page demonstrates how to subscribe to web events in Electron.
-        </p>
+        <p className="mb-4">This page demonstrates how to subscribe to web events in Electron.</p>
         <div className="p-4 bg-gray-100 rounded">
           <h2 className="text-xl font-semibold mb-2">Web Focus State</h2>
           <p className="text-lg">
@@ -86,14 +85,10 @@ function RouteComponent() {
             </span>
           </p>
 
-          <h2 className="text-xl font-semibold mt-4 mb-2">
-            Browser Focus State
-          </h2>
+          <h2 className="text-xl font-semibold mt-4 mb-2">Browser Focus State</h2>
           <p className="text-lg">
             The browser window is currently{' '}
-            <span
-              className={isBlurredByBrowser ? 'text-red-500' : 'text-green-500'}
-            >
+            <span className={isBlurredByBrowser ? 'text-red-500' : 'text-green-500'}>
               {isBlurredByBrowser ? 'blurred' : 'focused'}
             </span>
           </p>
@@ -103,17 +98,15 @@ function RouteComponent() {
           は、Electronのメインプロセスやプリロードスクリプト経由で「ウィンドウ全体のフォーカス状態」を検知するための独自APIです。
           一方、Web標準API（例: `window.addEventListener(`blur`, ...)` や
           `focus`）は、**ブラウザやWebViewのウィンドウがアクティブかどうか**を検知します。
-          主な違いは以下の通りです： ###
-          Electron独自API（`electronApi.web.subscribeBlur` など） -
+          主な違いは以下の通りです： ### Electron独自API（`electronApi.web.subscribeBlur` など） -
           Electronアプリのウィンドウ全体の状態を検知できる -
           メインプロセスやプリロードスクリプト経由でイベントを受け取る -
           Web標準APIよりも「アプリ全体の状態」に近い ###
           Web標準API（`window.addEventListener(`blur`, ...)` など） -
           ブラウザやWebViewのウィンドウがアクティブかどうかを検知 -
           Electron以外の通常のWebアプリでも動作 -
-          Electronでも使えるが、Electron独自APIほど細かい制御はできない場合がある
-          #### まとめ - **Electron
-          API**はElectronアプリ専用で、よりアプリ全体の状態を正確に検知できる -
+          Electronでも使えるが、Electron独自APIほど細かい制御はできない場合がある #### まとめ -
+          **Electron API**はElectronアプリ専用で、よりアプリ全体の状態を正確に検知できる -
           **Web標準API**は汎用的で、Electron以外でも使えるが、検知できる範囲がやや狭い
           どちらを使うかは、アプリの要件や動作させたい環境によって選択します。
         </pre>

--- a/src/routes/(app)/settings.tsx
+++ b/src/routes/(app)/settings.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+
 import { Link, createFileRoute } from '@tanstack/react-router'
 
 import { ThemeSwitcher as ModeSwitcher } from '@/components/theme-switcher'
@@ -33,35 +34,21 @@ export const Route = createFileRoute('/(app)/settings')({
 function RouteComponent() {
   const { auth } = Route.useRouteContext()
 
-  const [language, setLanguage] = useLocalStorageState<'ja' | 'en'>(
-    'settings.language',
-    'ja',
-  )
+  const [language, setLanguage] = useLocalStorageState<'ja' | 'en'>('settings.language', 'ja')
   const [restoreOnLaunch, setRestoreOnLaunch] = useLocalStorageState(
     'settings.restoreOnLaunch',
     true,
   )
-  const [notifications, setNotifications] = useLocalStorageState(
-    'settings.notifications',
-    true,
-  )
-  const [autoUpdate, setAutoUpdate] = useLocalStorageState(
-    'settings.autoUpdate',
-    true,
-  )
-  const [downloadDir, setDownloadDir] = useLocalStorageState(
-    'settings.downloadDir',
-    '',
-  )
+  const [notifications, setNotifications] = useLocalStorageState('settings.notifications', true)
+  const [autoUpdate, setAutoUpdate] = useLocalStorageState('settings.autoUpdate', true)
+  const [downloadDir, setDownloadDir] = useLocalStorageState('settings.downloadDir', '')
 
   return (
     <div className="w-full h-full">
       <div className="max-w-4xl mx-auto p-6 space-y-6">
         <div className="space-y-1">
           <h1 className="text-xl font-semibold">設定</h1>
-          <p className="text-sm text-muted-foreground">
-            テーマ、見た目、動作に関する基本設定
-          </p>
+          <p className="text-sm text-muted-foreground">テーマ、見た目、動作に関する基本設定</p>
         </div>
 
         <Card>
@@ -74,9 +61,7 @@ function RouteComponent() {
             <div className="space-y-2">
               <div className="text-sm font-medium">モード</div>
               <ModeSwitcher className="justify-start" />
-              <div className="text-xs text-muted-foreground">
-                ライト / ダーク / システム
-              </div>
+              <div className="text-xs text-muted-foreground">ライト / ダーク / システム</div>
             </div>
 
             <Separator />
@@ -109,10 +94,7 @@ function RouteComponent() {
                   表示言語（画面の文言は順次対応）
                 </div>
               </div>
-              <Select
-                value={language}
-                onValueChange={(v) => setLanguage(v as 'ja' | 'en')}
-              >
+              <Select value={language} onValueChange={(v) => setLanguage(v as 'ja' | 'en')}>
                 <SelectTrigger className="w-[180px]">
                   <SelectValue placeholder="選択" />
                 </SelectTrigger>

--- a/src/routes/(app)/ui/$component.tsx
+++ b/src/routes/(app)/ui/$component.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+
 import { createFileRoute } from '@tanstack/react-router'
 
 import { FullscreenWrapper } from '@/components/fullscreen-wrapper'
@@ -9,15 +10,10 @@ export const Route = createFileRoute('/(app)/ui/$component')({
 })
 
 // glob はモジュールスコープで1回
-const modules = import.meta.glob(
-  '/src/features/ui-demo/components/*-example.tsx',
-)
+const modules = import.meta.glob('/src/features/ui-demo/components/*-example.tsx')
 
 // ★ここで「全部の Lazy コンポーネント」を render の外で作る
-const registry: Record<
-  string,
-  React.LazyExoticComponent<React.ComponentType<any>>
-> = {}
+const registry: Record<string, React.LazyExoticComponent<React.ComponentType<any>>> = {}
 
 for (const [path, importer] of Object.entries(modules)) {
   const m = path.match(/\/([^/]+)-example\.tsx$/)

--- a/src/routes/(app)/ui/index.tsx
+++ b/src/routes/(app)/ui/index.tsx
@@ -1,26 +1,15 @@
 import * as React from 'react'
+
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { MoonIcon, SunIcon } from 'lucide-react'
 import { z } from 'zod'
 
 import type { Theme as AppearanceMode } from '#/main/api/theme'
-
-import type { Style } from '@/features/style/components/style-provider'
 import { useTheme as useAppearanceMode } from '@/components/theme-provider'
 import { ThemeSwitcher as ModeSwitcher } from '@/components/theme-switcher'
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from '@/components/ui/hover-card'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { Item } from '@/components/ui/item'
 import { Label } from '@/components/ui/label'
 import {
@@ -32,21 +21,6 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from '@/components/ui/pagination'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
-
-import { useTheme } from '@/features/style/api/use-theme'
-import { useStyle } from '@/features/style/api/use-style'
-import { STYLES } from '@/features/style/components/style-provider'
-import { StyleSwitcher } from '@/features/style/components/style-switcher'
-import { ThemeSwitcher } from '@/features/style/components/theme-switcher'
-import { components } from '@/features/ui-demo/constants'
-
-import { useIframeMessage } from '@/hooks/use-iframe-message'
-import { formatKebabAsTitle } from '@/lib/format-kebab-as-title'
-import { getPaginationItems } from '@/lib/pagination'
-import { cn } from '@/lib/utils'
-import { THEMES } from '@/features/style/components/themes'
-import { applyTheme } from '@/features/style/components/theme-provider'
 import {
   Popover,
   PopoverContent,
@@ -55,6 +29,20 @@ import {
   PopoverTitle,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { useStyle } from '@/features/style/api/use-style'
+import { useTheme } from '@/features/style/api/use-theme'
+import type { Style } from '@/features/style/components/style-provider'
+import { STYLES } from '@/features/style/components/style-provider'
+import { StyleSwitcher } from '@/features/style/components/style-switcher'
+import { applyTheme } from '@/features/style/components/theme-provider'
+import { ThemeSwitcher } from '@/features/style/components/theme-switcher'
+import { THEMES } from '@/features/style/components/themes'
+import { components } from '@/features/ui-demo/constants'
+import { useIframeMessage } from '@/hooks/use-iframe-message'
+import { formatKebabAsTitle } from '@/lib/format-kebab-as-title'
+import { getPaginationItems } from '@/lib/pagination'
+import { cn } from '@/lib/utils'
 
 const SearchSchema = z.object({
   page: z.number().default(0).optional(),
@@ -107,36 +95,21 @@ function RouteComponent() {
   )
 
   const filteredComponents = components.filter((_, index) => {
-    return (
-      index >= page * componentsPerPage &&
-      index < (page + 1) * componentsPerPage
-    )
+    return index >= page * componentsPerPage && index < (page + 1) * componentsPerPage
   })
 
   return (
     <div className="p-2 flex gap-2 flex-col bg-accent h-full overflow-auto">
       <div className="p-2 bg-background flex flex-wrap gap-2 items-center justify-start border border-border">
-        <Item
-          size="xs"
-          variant="outline"
-          className="flex-col w-fit items-start"
-        >
+        <Item size="xs" variant="outline" className="flex-col w-fit items-start">
           <Label className="text-muted-foreground text-xs">モード</Label>
           <ModeSwitcher />
         </Item>
-        <Item
-          size="xs"
-          variant="outline"
-          className="flex-col w-fit items-start"
-        >
+        <Item size="xs" variant="outline" className="flex-col w-fit items-start">
           <Label className="text-muted-foreground text-xs">スタイル</Label>
           <StyleSwitcher />
         </Item>
-        <Item
-          size="xs"
-          variant="outline"
-          className="flex-col w-fit items-start"
-        >
+        <Item size="xs" variant="outline" className="flex-col w-fit items-start">
           <Label className="text-muted-foreground text-xs">テーマ</Label>
           <ThemeSwitcher className="text-xs" />
         </Item>
@@ -192,10 +165,7 @@ function RouteComponent() {
                   componentsPerPage={componentsPerPage}
                   componentNames={components}
                 >
-                  <PaginationLink
-                    onClick={() => setPage(item)}
-                    isActive={item === page}
-                  >
+                  <PaginationLink onClick={() => setPage(item)} isActive={item === page}>
                     {item + 1}
                   </PaginationLink>
                 </PaginationHoverPreview>
@@ -241,10 +211,7 @@ function PaginationHoverPreview({
 }) {
   const pageComponents = React.useMemo(() => {
     if (pageIndex < 0) return []
-    return componentNames.slice(
-      pageIndex * componentsPerPage,
-      (pageIndex + 1) * componentsPerPage,
-    )
+    return componentNames.slice(pageIndex * componentsPerPage, (pageIndex + 1) * componentsPerPage)
   }, [componentNames, componentsPerPage, pageIndex])
 
   return (
@@ -266,15 +233,7 @@ function PaginationHoverPreview({
   )
 }
 
-function Content({
-  title,
-  src,
-  to,
-}: {
-  title: string
-  src: string
-  to: string
-}) {
+function Content({ title, src, to }: { title: string; src: string; to: string }) {
   const navigate = useNavigate()
 
   const { theme: currentMode } = useAppearanceMode()
@@ -287,10 +246,7 @@ function Content({
   const [style, setStyle] = React.useState<Style>(currentStyle)
 
   const handleMessage = React.useCallback(
-    (
-      window: Window,
-      data: { mode?: AppearanceMode; theme?: string; style?: Style },
-    ) => {
+    (window: Window, data: { mode?: AppearanceMode; theme?: string; style?: Style }) => {
       const html = window.document.documentElement
 
       if (data.style) {
@@ -341,25 +297,13 @@ function Content({
           <div className="text-lg font-semibold">{title}</div>
           <div className="flex gap-2">
             <DemoModeSwitcher value={mode} onValueChange={handleModeChange} />
-            <DemoStyleSwitcher
-              value={style}
-              onValueChange={handleStyleChange}
-            />
-            <DemoThemeSwitcher
-              value={theme}
-              onValueChange={handleThemeChange}
-            />
+            <DemoStyleSwitcher value={style} onValueChange={handleStyleChange} />
+            <DemoThemeSwitcher value={theme} onValueChange={handleThemeChange} />
           </div>
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <iframe
-          ref={ref}
-          src={src}
-          width={550}
-          height={550}
-          className="border rounded-xl"
-        />
+        <iframe ref={ref} src={src} width={550} height={550} className="border rounded-xl" />
       </CardContent>
       <CardFooter>
         <Button variant="link" onClick={() => navigate({ to })}>
@@ -413,17 +357,12 @@ function DemoThemeSwitcher({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          className={cn(className, 'min-w-20 flex items-center')}
-        >
+        <Button variant="outline" className={cn(className, 'min-w-20 flex items-center')}>
           {formatKebabAsTitle(value)}
           <div
             className="size-4 rounded-full"
             style={{
-              backgroundColor: THEMES.find((t) => t.name === value)?.cssVars[
-                'light'
-              ]['primary'],
+              backgroundColor: THEMES.find((t) => t.name === value)?.cssVars['light']['primary'],
             }}
           ></div>
         </Button>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,16 +1,14 @@
+import { aiDevtoolsPlugin } from '@tanstack/react-ai-devtools'
+import { TanStackDevtools } from '@tanstack/react-devtools'
+import type { QueryClient } from '@tanstack/react-query'
 import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
-import { TanStackDevtools } from '@tanstack/react-devtools'
-import { aiDevtoolsPlugin } from '@tanstack/react-ai-devtools'
+
+import { useDevTools } from '@/components/devtools-provider'
+import type { AuthState } from '@/features/auth/api/auth'
 
 import { Layout } from '../components/layout'
-
 import TanStackQueryDevtools from '../integrations/tanstack-query/devtools'
-
-import type { QueryClient } from '@tanstack/react-query'
-
-import type { AuthState } from '@/features/auth/api/auth'
-import { useDevTools } from '@/components/devtools-provider'
 
 const isDev = import.meta.env.DEV
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+
 import logo from '@/assets/logo.svg'
 
 export const Route = createFileRoute('/')({

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+
 import { createFileRoute, redirect, useRouter } from '@tanstack/react-router'
 
 type LoginSearch = {
@@ -49,8 +50,7 @@ function LoginRouteComponent() {
         <div className="space-y-1">
           <h1 className="text-lg font-semibold">Login</h1>
           <p className="text-sm text-muted-foreground">
-            オフライン認証: 初回はユーザー作成、その後はパスワード検証（SQLite /
-            Main管理）
+            オフライン認証: 初回はユーザー作成、その後はパスワード検証（SQLite / Main管理）
           </p>
         </div>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'vite'
-import { devtools } from '@tanstack/devtools-vite'
-import react, { reactCompilerPreset } from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-import { tanstackRouter } from '@tanstack/router-plugin/vite'
-import { electron } from '@srymh/vite-plugin-electron'
 import babel from '@rolldown/plugin-babel'
+import { electron } from '@srymh/vite-plugin-electron'
+import tailwindcss from '@tailwindcss/vite'
+import { devtools } from '@tanstack/devtools-vite'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
+import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -21,9 +21,7 @@ export default defineConfig(({ mode }) => {
 
   // React Compiler を使用するとデバッグ時にブレークポイントが正しく動作しないため、
   // ソースマップを有効にしたい場合には React Compiler を無効化します。
-  const reactCompilerPlugin = !sourcemap
-    ? [babel({ presets: [reactCompilerPreset()] })]
-    : []
+  const reactCompilerPlugin = !sourcemap ? [babel({ presets: [reactCompilerPreset()] })] : []
 
   return {
     base,
@@ -76,9 +74,7 @@ export default defineConfig(({ mode }) => {
     ],
     clearScreen: false,
     define: {
-      __PLATFORM__: JSON.stringify(
-        process.env.TARGET_PLATFORM ?? process.platform,
-      ),
+      __PLATFORM__: JSON.stringify(process.env.TARGET_PLATFORM ?? process.platform),
     },
     resolve: { tsconfigPaths: true },
     test: {


### PR DESCRIPTION
## 概要

- oxlint と oxfmt の設定を見直し、import/type import の統一ルールに合わせてコード全体へ機械的な整形を適用
- build 手順を lint 前提に更新し、version を 0.1.0-alpha.1 に更新

## 変更内容

- oxlint に import 関連ルールを追加し、React 系ルールは src 配下の override に限定
- oxfmt に import sort group と internalPattern を追加し、ignorePatterns を見直し
- build スクリプトを pnpm lint && vite build && electron-builder に変更
- Electron main、IPC、RAG、chat、table、routes など広範なファイルで import 並び替え、type import 分離、整形を適用
- 既存テストファイルも同方針で更新

## 影響範囲

- 設定変更: lint/format ルール、build 手順、version に影響
- アプリ本体の広い領域に差分があるが、確認できた範囲では import 整理と整形が中心

## 動作確認

- [x] `pnpm test` が成功する
- [x] `pnpm dev` で起動できる
- [ ] `pnpm build` でビルドして exe を起動できる
- [x] `pnpm build` でビルドして app を起動できる

## レビュー観点

- build 前に lint を必須化したことで、既存環境や CI でビルド失敗が増えないか
- oxlint/oxfmt の新ルールが Electron 側コードや除外対象ファイルに想定外の影響を与えていないか
- 大量の機械的差分に紛れた非意図の挙動変更がないか。特に auth、chat、ipc、rag、table 周辺を重点確認

## 関連リンク

- なし