### PR TITLE
fix(table): テーブルフィルター入力の空値処理を修正

### DIFF
--- a/apps/web/src/components/table/basic-table.tsx
+++ b/apps/web/src/components/table/basic-table.tsx
@@ -35,10 +35,11 @@ export function BasicTable<T>(props: {
   table: Table<T>
   rerender?: () => void
   refreshData?: () => void
+  debug?: boolean
 }) {
   'use no memo'
 
-  const { table, rerender, refreshData } = props
+  const { table, rerender, refreshData, debug = false } = props
 
   const pinColumn = React.useMemo(
     () =>
@@ -181,7 +182,7 @@ export function BasicTable<T>(props: {
       </div>
       <div className="h-4" />
       <Pagination table={table} />
-      <DebugInfo table={table} rerender={rerender} refreshData={refreshData} />
+      {debug && <DebugInfo table={table} rerender={rerender} refreshData={refreshData} />}
     </div>
   )
 }
@@ -203,7 +204,7 @@ function RowPinHeader<T>(props: HeaderContext<T, unknown>) {
         }
       }}
       disabled={!table.getIsSomeRowsPinned()}
-      className="cursor-pointer bg-white dark:bg-white"
+      className="cursor-pointer"
     />
   )
 }
@@ -223,7 +224,7 @@ function RowPinCell<T>(props: CellContext<T, unknown>) {
           row.pin(false)
         }
       }}
-      className="cursor-pointer bg-white dark:bg-white"
+      className="cursor-pointer"
     />
   )
 }
@@ -399,7 +400,7 @@ function GlobalFilter(props: {
 
   const { globalFilter = '', onChangeGlobalFilter } = props
 
-  const handleChange = (value: string | number) => {
+  const handleChange = (value: string | number | undefined) => {
     onChangeGlobalFilter(String(value))
   }
 

--- a/apps/web/src/components/table/debounced-input.tsx
+++ b/apps/web/src/components/table/debounced-input.tsx
@@ -9,8 +9,8 @@ export function DebouncedInput({
   debounce = 500,
   ...props
 }: {
-  value: string | number
-  onChange: (value: string | number) => void
+  value: string | number | undefined
+  onChange: (value: string | number | undefined) => void
   debounce?: number
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>) {
   'use no memo'
@@ -47,7 +47,11 @@ export function DebouncedInput({
       value={value}
       onChange={(e) => {
         shouldNotifyRef.current = true
-        setValue(e.target.value)
+        if (props.type === 'number' && e.target.value === '') {
+          setValue(undefined)
+        } else {
+          setValue(e.target.value)
+        }
       }}
     />
   )

--- a/apps/web/src/components/table/filter.tsx
+++ b/apps/web/src/components/table/filter.tsx
@@ -29,7 +29,13 @@ export function Filter({ column }: { column: Column<any, unknown> }) {
           min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
           max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
           value={columnFilterValue?.[0] ?? ''}
-          onChange={(value) => column.setFilterValue((old: [number, number]) => [value, old[1]])}
+          onChange={(value) =>
+            column.setFilterValue((old: [number, number] | undefined) => {
+              const lo = Number(value)
+              const hi = old?.[1] ?? ''
+              return [lo, hi]
+            })
+          }
           placeholder={`Min ${
             column.getFacetedMinMaxValues()?.[0] !== undefined
               ? `(${column.getFacetedMinMaxValues()?.[0]})`
@@ -41,7 +47,13 @@ export function Filter({ column }: { column: Column<any, unknown> }) {
           min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
           max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
           value={columnFilterValue?.[1] ?? ''}
-          onChange={(value) => column.setFilterValue((old: [number, number]) => [old[0], value])}
+          onChange={(value) =>
+            column.setFilterValue((old: [number, number] | undefined) => {
+              const lo = old?.[0] ?? ''
+              const hi = Number(value)
+              return [lo, hi]
+            })
+          }
           placeholder={`Max ${
             column.getFacetedMinMaxValues()?.[1] ? `(${column.getFacetedMinMaxValues()?.[1]})` : ''
           }`}


### PR DESCRIPTION
- テーブル関連コンポーネントで空値を扱えるように型と更新処理を修正
- DebouncedInput の value/onChange を undefined 対応にし、数値入力を空にしたときは undefined を保持するよう変更
- 範囲フィルターの更新時に既存値が未設定でも下限・上限を組み立てられるようにした
- BasicTable のデバッグ情報を debug フラグで制御し、行ピン留め操作の不要な背景色指定を削除