### PR TITLE
feat!: ユーザーデータパス修正と sqlite API 名称統一

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@your-app-name/api",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "your-app-name",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "dist/main/index.js",

--- a/apps/desktop/src/main/api/kakeibo.ts
+++ b/apps/desktop/src/main/api/kakeibo.ts
@@ -1,7 +1,7 @@
 import type { WebContents } from 'electron'
 
 import type { ApiInterface, WithWebContentsApi } from '@repo/ipc'
-import type { DataBase } from '@repo/sqlite'
+import type { Database } from '@repo/sqlite'
 
 // -----------------------------------------------------------------------------
 // 型定義
@@ -10,7 +10,7 @@ export const Kakeibo_API_KEY = 'kakeibo' as const
 export type KakeiboApiKey = typeof Kakeibo_API_KEY
 
 export type KakeiboContext = {
-  getDb: () => DataBase
+  getDb: () => Database
 }
 
 export type KakeiboEntry = {

--- a/apps/desktop/src/main/app/startApp.ts
+++ b/apps/desktop/src/main/app/startApp.ts
@@ -1,6 +1,10 @@
 import { app, BrowserWindow } from 'electron'
 
+import type { MainPaths } from '../infra/paths'
+import { resolveMainPaths } from '../infra/paths'
+
 export interface AppRuntime {
+  paths: MainPaths
   // 破棄処理を追加する
   addDispose(dispose: () => void | Promise<void>): void
 }
@@ -9,6 +13,7 @@ export interface AppRuntime {
 const DEFAULT_DISPOSE_TIMEOUT_MS = 5_000
 
 export async function startApp<TAppContext>(options: {
+  dirname: string
   onAppReady: ({
     appRuntime,
     appContext,
@@ -23,21 +28,26 @@ export async function startApp<TAppContext>(options: {
     appRuntime: AppRuntime
     appContext: TAppContext
   }) => void
-  createAppContext: () => Promise<TAppContext>
+  createAppContext: ({ appRuntime }: { appRuntime: AppRuntime }) => Promise<TAppContext>
 }) {
-  const { onAppReady, openMainWindow, createAppContext } = options
-
-  const appContext: TAppContext = await createAppContext()
+  const { dirname, onAppReady, openMainWindow, createAppContext } = options
 
   /** before-quit で呼ばれる破棄処理（同期/非同期混在可） */
   const disposeSet: Set<(() => void) | (() => Promise<void>)> = new Set()
   let isDisposing = false
 
   const appRuntime: AppRuntime = {
+    paths: resolveMainPaths({
+      isPackaged: app.isPackaged,
+      dirname,
+      userDataPath: app.getPath('userData'),
+    }),
     addDispose(dispose) {
       disposeSet.add(dispose)
     },
   }
+
+  const appContext: TAppContext = await createAppContext({ appRuntime })
 
   /** --------------------------------------------------------------------------
    *

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,12 +10,12 @@ import type { AiChatSession } from '@repo/ai-chat-session'
 import type { AuthRuntime } from '@repo/auth'
 import { createAuthRuntime } from '@repo/auth'
 import type { McpServer } from '@repo/mcp-server-example'
-import type { DataBase } from '@repo/sqlite'
+import type { Database } from '@repo/sqlite'
 import { mcpToTanStackAiTools } from '@repo/tanstack-ai-mcp'
 
 import { startApp } from './app/startApp'
 import type { AppRuntime } from './app/startApp'
-import { createAppDataBase } from './infra/db'
+import { createAppDatabase } from './infra/db'
 import { resolveMainPaths } from './infra/paths'
 import type { MainPaths } from './infra/paths'
 import { registerCustomProtocol } from './infra/registerCustomProtocol'
@@ -37,7 +37,7 @@ type AppContext = {
   windowContextMap: WeakMap<WebContents, Context>
 
   mcpServer: McpServer | null
-  db: DataBase | null
+  db: Database | null
   toolsByMcp: ServerTool[] | null
   authRuntime: AuthRuntime | null
   aiChatSession: AiChatSession | null
@@ -220,7 +220,7 @@ function createWindowContext(
       getDb: () => {
         if (!appContext.db) {
           try {
-            const db = createAppDataBase(path.join(appContext.paths.dataPath, 'kakeibo.db'), {
+            const db = createAppDatabase(path.join(appContext.paths.dataPath, 'kakeibo.db'), {
               readonly: false,
               fileMustExist: false,
             })
@@ -245,12 +245,12 @@ function createWindowContext(
          * desktop app 用に auth.db の実体を開く factory。
          * 認証スキーマ初期化は @repo/auth 側で行う。
          */
-        function createAuthDb(): DataBase {
+        function createAuthDb(): Database {
           const dbPath = path.join(app.getPath('userData'), 'auth.db')
 
           console.log(`Auth DB Path: ${dbPath}`)
 
-          return createAppDataBase(dbPath)
+          return createAppDatabase(dbPath)
         }
 
         const newRuntime = createAuthRuntime({

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-import { app } from 'electron'
 import type { WebContents, BrowserWindow } from 'electron'
 
 import type { ServerTool } from '@tanstack/ai'
@@ -16,8 +15,6 @@ import { mcpToTanStackAiTools } from '@repo/tanstack-ai-mcp'
 import { startApp } from './app/startApp'
 import type { AppRuntime } from './app/startApp'
 import { createAppDatabase } from './infra/db'
-import { resolveMainPaths } from './infra/paths'
-import type { MainPaths } from './infra/paths'
 import { registerCustomProtocol } from './infra/registerCustomProtocol'
 import { registerIpc } from './ipc/registerIpc'
 import type { Context } from './ipc/registerIpc'
@@ -43,10 +40,10 @@ type AppContext = {
   aiChatSession: AiChatSession | null
 
   registerIpcCache: WeakMap<WebContents, Map<string, () => void>>
-  paths: MainPaths
 }
 
 startApp<AppContext>({
+  dirname: __dirname,
   /** --------------------------------------------------------------------------
    *
    * app 準備完了後の処理
@@ -89,8 +86,8 @@ startApp<AppContext>({
      */
     const ensureTrailingSeparator = (p: string) => (p.endsWith(path.sep) ? p : p + path.sep)
 
-    const rendererRootUrl = appContext.paths.rendererDist
-      ? pathToFileURL(ensureTrailingSeparator(appContext.paths.rendererDist)).toString()
+    const rendererRootUrl = appRuntime.paths.rendererDist
+      ? pathToFileURL(ensureTrailingSeparator(appRuntime.paths.rendererDist)).toString()
       : null
 
     createWindow(
@@ -98,7 +95,7 @@ startApp<AppContext>({
         if (VITE_DEV_SERVER_URL) {
           await win.loadURL(VITE_DEV_SERVER_URL)
         } else {
-          await win.loadFile(appContext.paths.indexHtmlPath)
+          await win.loadFile(appRuntime.paths.indexHtmlPath)
         }
       },
       {
@@ -106,7 +103,7 @@ startApp<AppContext>({
          * BrowserWindow のオプション設定
          * ------------------------------------------------------------------ */
         browserWindowOptions: {
-          icon: getAppIconPath(appContext.paths.desktopPublic),
+          icon: getAppIconPath(appRuntime.paths.desktopPublic),
           autoHideMenuBar: process.platform !== 'darwin',
           // タイトルバーを完全に消す
           titleBarStyle: 'hidden',
@@ -115,7 +112,7 @@ startApp<AppContext>({
           ...(process.platform !== 'darwin' ? { titleBarOverlay: createTitleBarOverlay() } : {}),
           webPreferences: {
             ...recommendedSecureOptions,
-            preload: appContext.paths.preloadPath,
+            preload: appRuntime.paths.preloadPath,
           },
         },
         /** --------------------------------------------------------------------
@@ -160,10 +157,6 @@ startApp<AppContext>({
       authRuntime: null,
       aiChatSession: null,
       registerIpcCache: new WeakMap(),
-      paths: resolveMainPaths({
-        isPackaged: app.isPackaged,
-        dirname: __dirname,
-      }),
     }
   },
 })
@@ -209,7 +202,7 @@ function createWindowContext(
         return toolsByMcp
       },
       getSearchProjectDetailDbPath: () => {
-        return path.join(appContext.paths.dataPath, 'example.db')
+        return path.join(appRuntime.paths.dataPath, 'example.db')
       },
       getAiChatSession: () => appContext.aiChatSession,
       setAiChatSession: (session) => {
@@ -220,7 +213,7 @@ function createWindowContext(
       getDb: () => {
         if (!appContext.db) {
           try {
-            const db = createAppDatabase(path.join(appContext.paths.dataPath, 'kakeibo.db'), {
+            const db = createAppDatabase(path.join(appRuntime.paths.dataPath, 'kakeibo.db'), {
               readonly: false,
               fileMustExist: false,
             })
@@ -246,7 +239,7 @@ function createWindowContext(
          * 認証スキーマ初期化は @repo/auth 側で行う。
          */
         function createAuthDb(): Database {
-          const dbPath = path.join(app.getPath('userData'), 'auth.db')
+          const dbPath = path.join(appRuntime.paths.userDataPath, 'auth.db')
 
           console.log(`Auth DB Path: ${dbPath}`)
 

--- a/apps/desktop/src/main/infra/db.ts
+++ b/apps/desktop/src/main/infra/db.ts
@@ -1,10 +1,10 @@
 /**
- * better-sqlite3 を @repo/sqlite の `DataBase` に接続する desktop app 側の adapter。
+ * better-sqlite3 を @repo/sqlite の `Database` に接続する desktop app 側の adapter。
  *
  * このファイルの責務:
  * - better-sqlite3 の生成を app 側に閉じ込める
  * - better-sqlite3 と `@repo/sqlite` の型差を吸収する
- * - 呼び出し側へ driver 非依存の `DataBase` を返す
+ * - 呼び出し側へ driver 非依存の `Database` を返す
  *
  * このファイルが決めないこと:
  * - DB ファイルの場所や名前
@@ -21,10 +21,10 @@ import type {
   Options as BetterSqlite3Options,
 } from 'better-sqlite3'
 
-import { createDataBase } from '@repo/sqlite'
-import type { DataBase, SqliteDatabaseHandle } from '@repo/sqlite'
+import { createDatabase } from '@repo/sqlite'
+import type { Database, SqliteDatabaseHandle } from '@repo/sqlite'
 
-export type DataBaseOpenOptions = {
+export type DatabaseOpenOptions = {
   readonly?: boolean
   fileMustExist?: boolean
 }
@@ -46,7 +46,7 @@ function createBetterSqlite3Handle(db: BetterSqlite3Database): SqliteDatabaseHan
   }
 }
 
-function toBetterSqlite3Options(options?: DataBaseOpenOptions): BetterSqlite3Options | undefined {
+function toBetterSqlite3Options(options?: DatabaseOpenOptions): BetterSqlite3Options | undefined {
   if (!options) {
     return undefined
   }
@@ -58,11 +58,11 @@ function toBetterSqlite3Options(options?: DataBaseOpenOptions): BetterSqlite3Opt
 }
 
 /**
- * 共通で扱う open option だけを受け取り、driver 非依存の `DataBase` を返します。
+ * 共通で扱う open option だけを受け取り、driver 非依存の `Database` を返します。
  * `filePath` の解決は呼び出し側の責務です。
  */
-export function createAppDataBase(filePath: string, options?: DataBaseOpenOptions): DataBase {
-  return createDataBase(
+export function createAppDatabase(filePath: string, options?: DatabaseOpenOptions): Database {
+  return createDatabase(
     createBetterSqlite3Handle(new BetterSqlite3(filePath, toBetterSqlite3Options(options))),
   )
 }

--- a/apps/desktop/src/main/infra/paths.ts
+++ b/apps/desktop/src/main/infra/paths.ts
@@ -28,7 +28,9 @@ import path from 'node:path'
  *   vitePublic:    '$root/public',
  *   preloadPath:   '$root/dist/preload/index.cjs',
  *   indexHtmlPath: '',
- *   dataPath:      '$root/data'
+ *   dataPath:      '$root/data',
+ *   userDataPath:  'C:\\Users\\ユーザー名\\AppData\\Roaming\\your-app-name\\app' (Windowsの場合)
+ *   userDataPath:  '/Users/ユーザー名/Library/Application Support/your-app-name/app' (macOSの場合)
  * }
  * ```
  *
@@ -58,7 +60,9 @@ import path from 'node:path'
  *   vitePublic:    '$root/resources/app.asar/web/dist',
  *   preloadPath:   '$root/resources/app.asar/dist/preload/index.cjs',
  *   indexHtmlPath: '$root/resources/app.asar/web/dist/index.html',
- *   dataPath:      '$root/resources/data'
+ *   dataPath:      '$root/resources/data',
+ *   userDataPath:  'C:\\Users\\ユーザー名\\AppData\\Roaming\\your-app-name\\app' (Windowsの場合)
+ *   userDataPath:  '/Users/ユーザー名/Library/Application Support/your-app-name/app' (macOSの場合)
  * }
  * ```
  *
@@ -88,7 +92,9 @@ import path from 'node:path'
  *   vitePublic:    '$root/resources/app/web/dist',
  *   preloadPath:   '$root/resources/app/dist/preload/index.cjs',
  *   indexHtmlPath: '$root/resources/app/web/dist/index.html',
- *   dataPath:      '$root/resources/data'
+ *   dataPath:      '$root/resources/data',
+ *   userDataPath:  'C:\\Users\\ユーザー名\\AppData\\Roaming\\your-app-name\\app' (Windowsの場合)
+ *   userDataPath:  '/Users/ユーザー名/Library/Application Support/your-app-name/app' (macOSの場合)
  * }
  * ```
  */
@@ -114,8 +120,10 @@ export type MainPaths = {
   preloadPath: string
   /** Renderer のエントリ HTML のパス（例: `web/dist/index.html`） */
   indexHtmlPath: string
-  /** data */
+  /** ビルトインの読み取り用データディレクトリ */
   dataPath: string
+  /** ユーザーデータ用ディレクトリ */
+  userDataPath: string
 }
 
 /**
@@ -133,8 +141,9 @@ export function resolveMainPaths(args: {
   isPackaged: boolean
   /** Equivalent to `path.dirname(fileURLToPath(import.meta.url))` in `src/main/index.ts` */
   dirname: string
+  userDataPath: string
 }): MainPaths {
-  const { isPackaged: isProd, dirname } = args
+  const { isPackaged: isProd, dirname, userDataPath } = args
 
   const appRoot = path.join(dirname, '..', '..')
 
@@ -155,6 +164,8 @@ export function resolveMainPaths(args: {
 
   const dataPath = isProd ? path.join(process.resourcesPath, 'data') : path.join(appRoot, 'data')
 
+  const userDataPathResolved = path.join(userDataPath, 'app')
+
   return {
     appRoot,
     mainDist,
@@ -164,5 +175,6 @@ export function resolveMainPaths(args: {
     preloadPath,
     indexHtmlPath,
     dataPath,
+    userDataPath: userDataPathResolved,
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@your-app-name/web",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/auth/src/index.test.ts
+++ b/packages/auth/src/index.test.ts
@@ -2,7 +2,7 @@ import { DatabaseSync } from 'node:sqlite'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import { createDataBase } from '@repo/sqlite'
+import { createDatabase } from '@repo/sqlite'
 import type { SqliteDatabaseHandle } from '@repo/sqlite'
 
 import { createAuthRuntime } from './index'
@@ -10,7 +10,7 @@ import { createAuthRuntime } from './index'
 describe('createAuthRuntime', () => {
   it('creates a user session on first login and returns the current auth status', () => {
     const createInMemoryDb = () =>
-      createDataBase(new DatabaseSync(':memory:') as unknown as SqliteDatabaseHandle)
+      createDatabase(new DatabaseSync(':memory:') as unknown as SqliteDatabaseHandle)
 
     const runtime = createAuthRuntime({
       createDb: createInMemoryDb,
@@ -39,7 +39,7 @@ describe('createAuthRuntime', () => {
     const closeSpy = vi.spyOn(handle, 'close')
 
     const runtime = createAuthRuntime({
-      db: createDataBase(handle as unknown as SqliteDatabaseHandle),
+      db: createDatabase(handle as unknown as SqliteDatabaseHandle),
       closeDbOnDispose: true,
     })
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 
-import type { DataBase } from '@repo/sqlite'
+import type { Database } from '@repo/sqlite'
 
 export type AuthUser = {
   username: string
@@ -20,13 +20,13 @@ export type AuthRuntime = {
 
 export type CreateAuthRuntimeOptions =
   | {
-      db: DataBase
+      db: Database
       createDb?: never
       closeDbOnDispose?: boolean
     }
   | {
       db?: never
-      createDb: () => DataBase
+      createDb: () => Database
       closeDbOnDispose?: boolean
     }
 
@@ -109,14 +109,14 @@ function verifyPassword(password: string, user: DbAuthUser) {
   return crypto.timingSafeEqual(a, b)
 }
 
-function revokeCurrentSession(db: DataBase, revokedAt: string) {
+function revokeCurrentSession(db: Database, revokedAt: string) {
   db.run(
     'UPDATE auth_sessions SET revoked_at = ?, is_current = 0 WHERE is_current = 1 AND revoked_at IS NULL',
     [revokedAt],
   )
 }
 
-function createCurrentSession(db: DataBase, userId: number) {
+function createCurrentSession(db: Database, userId: number) {
   const createdAt = nowIso()
   const expiresAt = computeExpiresAtIso()
 
@@ -126,7 +126,7 @@ function createCurrentSession(db: DataBase, userId: number) {
   )
 }
 
-function readCurrentSessionUser(db: DataBase): DbAuthSessionWithUser | undefined {
+function readCurrentSessionUser(db: Database): DbAuthSessionWithUser | undefined {
   return db.get<DbAuthSessionWithUser>(
     [
       'SELECT u.username as username, s.expires_at as expires_at',
@@ -139,7 +139,7 @@ function readCurrentSessionUser(db: DataBase): DbAuthSessionWithUser | undefined
 }
 
 function resolveRuntimeDb(options: CreateAuthRuntimeOptions): {
-  db: DataBase
+  db: Database
   closeDbOnDispose: boolean
 } {
   if (options.createDb) {
@@ -155,7 +155,7 @@ function resolveRuntimeDb(options: CreateAuthRuntimeOptions): {
   }
 }
 
-export function ensureAuthDb(db: DataBase): void {
+export function ensureAuthDb(db: Database): void {
   db.exec(
     [
       'PRAGMA foreign_keys = ON;',
@@ -188,7 +188,7 @@ export function ensureAuthDb(db: DataBase): void {
   )
 }
 
-export function getAuthStatus(db: DataBase): AuthStatus {
+export function getAuthStatus(db: Database): AuthStatus {
   const row = readCurrentSessionUser(db)
   if (!row) {
     return { isAuthenticated: false, user: null }
@@ -212,7 +212,7 @@ export function getAuthStatus(db: DataBase): AuthStatus {
   }
 }
 
-export function login(db: DataBase, username: string, password: string): AuthStatus {
+export function login(db: Database, username: string, password: string): AuthStatus {
   const normalized = username.trim()
   if (!normalized) {
     throw new Error('username is required')
@@ -288,7 +288,7 @@ export function login(db: DataBase, username: string, password: string): AuthSta
   }
 }
 
-export function logout(db: DataBase): void {
+export function logout(db: Database): void {
   revokeCurrentSession(db, nowIso())
 }
 

--- a/packages/rag/scripts/example.txt
+++ b/packages/rag/scripts/example.txt
@@ -72,7 +72,7 @@ AppContext は以下のフィールドを持つ。
 
 - windowsById: Map<string, BrowserWindow> でウィンドウを ID で管理する。
 - mcpServer: MCP サーバーインスタンス。
-- db: better-sqlite3 の DataBase ラッパーインスタンス。
+- db: better-sqlite3 の Database ラッパーインスタンス。
 - authRuntime: 認証ランタイム（AuthRuntime）。
 
 startApp 関数はジェネリックなアプリケーションライフサイクルマネージャーである。electron/main/app/startApp.ts に定義されており、初期化・ウィンドウ作成・破棄のライフサイクルを管理する。dispose パターンにより、アプリ終了時にリソースを確実に解放する。
@@ -283,7 +283,7 @@ electron/shared/lib/tanstack-ai-mcp/index.ts には mcpToTanStackAiTools ユー�
 
 アプリケーションデータには better-sqlite3 を使用する。データベースファイルは data/kakeibo.db に配置される。
 
-packages/sqlite/src/index.ts に DataBase クラスが定義されている。apps/desktop/electron/main/infra/db.ts は better-sqlite3 をその抽象へ接続する adapter である。DataBase は以下のメソッドを提供する。
+packages/sqlite/src/index.ts に Database クラスが定義されている。apps/desktop/electron/main/infra/db.ts は better-sqlite3 をその抽象へ接続する adapter である。Database は以下のメソッドを提供する。
 
 - query(): SELECT クエリを実行し結果の配列を返す。
 - get(): 単一行を取得する。

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -10,7 +10,7 @@ export type SqliteDatabaseHandle = {
   close: () => void
 }
 
-export class DataBase {
+export class Database {
   constructor(private readonly db: SqliteDatabaseHandle) {}
 
   query<T = unknown>(sql: string, params?: readonly unknown[]): T[] {
@@ -42,6 +42,6 @@ export class DataBase {
   }
 }
 
-export function createDataBase(db: SqliteDatabaseHandle): DataBase {
-  return new DataBase(db)
+export function createDatabase(db: SqliteDatabaseHandle): Database {
+  return new Database(db)
 }


### PR DESCRIPTION
## 概要

- Electron メインプロセスのパス解決を AppRuntime に集約し、userData を含む実行時パスの参照を整理した
- @repo/sqlite の公開 API 名を DataBase/createDataBase から Database/createDatabase に統一した

## 変更内容

- startApp が dirname と解決済み paths を受け持つ構成に変わり、ウィンドウ起動時の preload、index.html、アイコン、DB 参照が AppRuntime 経由になった
- MainPaths に userDataPath を追加し、app.getPath('userData') を基に app 配下の保存先を解決するようにした
- apps/desktop と packages/auth の sqlite 利用コードを新しい Database 命名へ追従させた
- packages/auth の既存テストと packages/rag のサンプル文書を名称変更に合わせて更新した
- CI 設定や scripts の変更はない

## 影響範囲

- apps/desktop のメインプロセス初期化、ウィンドウ生成時のパス解決、認証 DB の保存先に影響する
- @repo/sqlite の公開 API 名変更を含むため、リポジトリ外や未追従の利用箇所があれば破壊的変更になる
- auth.db の保存先が従来から変わる可能性があるため、既存ユーザーデータの移行要否を確認する必要がある

## 動作確認

- [x] pnpm test が成功する
- [x] pnpm dev で起動できる
- [ ] pnpm build でビルドして .exe を起動できる
- [x] pnpm build でビルドして .app を起動できる

## レビュー観点

- dev 環境と packaged 環境の両方で preload、index.html、data、userData の各パスが意図通り解決されるか
- 既存の auth.db を新しい userData/app 配下へ移す必要があるか -> あり
- @repo/sqlite の旧 API 名を参照する downstream や未更新コードが残っていないか

## 関連リンク

- なし
