### PR TITLE
build(deps): package.jsonの依存関係を整理

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,10 +16,6 @@
     "@repo/frame-rpc": "workspace:*",
     "your-app-name": "workspace:*"
   },
-  "devDependencies": {
-    "@types/node": "^24.12.2",
-    "oxlint": "^1.63.0"
-  },
   "devEngines": {
     "packageManager": {
       "name": "pnpm",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,24 +26,19 @@
     "@repo/mcp-server-example": "workspace:*",
     "@repo/sqlite": "workspace:*",
     "@repo/tanstack-ai-mcp": "workspace:*",
-    "@standard-schema/spec": "^1.1.0",
     "@tanstack/ai": "^0.14.0",
     "better-sqlite3": "^12.9.0",
-    "express": "^5.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.4",
     "@srymh/vite-plugin-electron": "0.2.0-beta.6",
     "@types/better-sqlite3": "^7.6.13",
-    "@types/express": "^5.0.6",
     "@types/node": "^24.12.2",
     "electron": "^41.5.0",
     "electron-builder": "^26.8.1",
-    "oxlint": "^1.63.0",
     "vite": "^8.0.10",
-    "vitest": "^4.1.5",
-    "web-vitals": "^5.2.0"
+    "vitest": "^4.1.5"
   },
   "devEngines": {
     "packageManager": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,6 @@
     "@repo/ai-chat": "workspace:*",
     "@repo/ai-tools": "workspace:*",
     "@repo/shadcn": "workspace:*",
-    "@standard-schema/spec": "^1.1.0",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/ai": "^0.14.0",
     "@tanstack/ai-client": "^0.8.0",

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@repo/async-queue": "workspace:*",
-    "@standard-schema/spec": "^1.1.0",
     "@tanstack/ai": "^0.14.0",
     "@tanstack/ai-ollama": "^0.6.10",
     "@tanstack/ai-react": "^0.8.0",

--- a/packages/ai-tools/package.json
+++ b/packages/ai-tools/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@repo/rag": "workspace:*",
-    "@standard-schema/spec": "^1.1.0",
     "@tanstack/ai": "^0.14.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,13 +225,6 @@ importers:
       your-app-name:
         specifier: workspace:*
         version: link:../desktop
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
-      oxlint:
-        specifier: ^1.63.0
-        version: 1.63.0
 
   apps/desktop:
     dependencies:
@@ -262,18 +255,12 @@ importers:
       '@repo/tanstack-ai-mcp':
         specifier: workspace:*
         version: link:../../packages/tanstack-ai-mcp
-      '@standard-schema/spec':
-        specifier: ^1.1.0
-        version: 1.1.0
       '@tanstack/ai':
         specifier: ^0.14.0
         version: 0.14.0
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
-      express:
-        specifier: ^5.2.1
-        version: 5.2.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -287,9 +274,6 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
-      '@types/express':
-        specifier: ^5.0.6
-        version: 5.0.6
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.3
@@ -299,18 +283,12 @@ importers:
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
-      oxlint:
-        specifier: ^1.63.0
-        version: 1.63.0
       vite:
         specifier: ^8.0.10
         version: 8.0.11(@types/node@24.12.3)(jiti@2.7.0)
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@24.12.3)(jsdom@29.1.1)(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
-      web-vitals:
-        specifier: ^5.2.0
-        version: 5.2.0
 
   apps/web:
     dependencies:
@@ -326,9 +304,6 @@ importers:
       '@repo/shadcn':
         specifier: workspace:*
         version: link:../../packages/shadcn
-      '@standard-schema/spec':
-        specifier: ^1.1.0
-        version: 1.1.0
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.3.0(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
@@ -444,9 +419,6 @@ importers:
       '@repo/async-queue':
         specifier: workspace:*
         version: link:../async-queue
-      '@standard-schema/spec':
-        specifier: ^1.1.0
-        version: 1.1.0
       '@tanstack/ai':
         specifier: ^0.14.0
         version: 0.14.0
@@ -488,9 +460,6 @@ importers:
       '@repo/rag':
         specifier: workspace:*
         version: link:../rag
-      '@standard-schema/spec':
-        specifier: ^1.1.0
-        version: 1.1.0
       '@tanstack/ai':
         specifier: ^0.14.0
         version: 0.14.0


### PR DESCRIPTION
- 複数 workspace の package.json から不要な依存関係と開発依存関係を削除
- apps/api から @types/node と oxlint の devDependencies を削除
- apps/desktop から @standard-schema/spec、express、@types/express、oxlint、web-vitals を削除
- apps/web、packages/ai-chat、packages/ai-tools から @standard-schema/spec を削除
- pnpm-lock.yaml を更新して削除した依存関係の解決結果を反映