### PR TITLE
fix(desktop): userData 配下の app ディレクトリを起動時に作成

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@your-app-name/api",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "your-app-name",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "main": "dist/main/index.js",

--- a/apps/desktop/src/main/app/startApp.ts
+++ b/apps/desktop/src/main/app/startApp.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow } from 'electron'
 
 import type { MainPaths } from '../infra/paths'
 import { resolveMainPaths } from '../infra/paths'
+import { ensureUserDataAppDirectory } from '../infra/userDataDirectory'
 
 export interface AppRuntime {
   paths: MainPaths
@@ -46,6 +47,8 @@ export async function startApp<TAppContext>(options: {
       disposeSet.add(dispose)
     },
   }
+
+  await ensureUserDataAppDirectory(appRuntime.paths.userDataPath)
 
   const appContext: TAppContext = await createAppContext({ appRuntime })
 

--- a/apps/desktop/src/main/infra/userDataDirectory.test.ts
+++ b/apps/desktop/src/main/infra/userDataDirectory.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ensureUserDataAppDirectory } from './userDataDirectory'
+
+const tmpDirs: string[] = []
+
+async function createTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'user-data-directory-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe('ensureUserDataAppDirectory', () => {
+  it('creates the app directory below userData when it does not exist', async () => {
+    const root = await createTempDir()
+    const userDataAppPath = path.join(root, 'userData', 'app')
+
+    await ensureUserDataAppDirectory(userDataAppPath)
+
+    const stats = await fs.stat(userDataAppPath)
+    expect(stats.isDirectory()).toBe(true)
+  })
+
+  it('does not fail when the directory already exists', async () => {
+    const root = await createTempDir()
+    const userDataAppPath = path.join(root, 'userData', 'app')
+    await fs.mkdir(userDataAppPath, { recursive: true })
+
+    await expect(ensureUserDataAppDirectory(userDataAppPath)).resolves.toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/infra/userDataDirectory.ts
+++ b/apps/desktop/src/main/infra/userDataDirectory.ts
@@ -1,0 +1,5 @@
+import fs from 'node:fs/promises'
+
+export async function ensureUserDataAppDirectory(userDataAppPath: string): Promise<void> {
+  await fs.mkdir(userDataAppPath, { recursive: true })
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@your-app-name/web",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- 起動時に解決済みの userData/app ディレクトリを再帰的に作成
- ディレクトリ作成 helper と既存ディレクトリ時のテストを追加