### PR TITLE
build: 開発依存と devEngines をルートに集約

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ count.txt
 .nitro
 .tanstack
 .wrangler
+.pnpm-store

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,12 +15,5 @@
   "dependencies": {
     "@repo/frame-rpc": "workspace:*",
     "your-app-name": "workspace:*"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -34,17 +34,8 @@
     "@electron/rebuild": "^4.0.4",
     "@srymh/vite-plugin-electron": "0.2.0-beta.6",
     "@types/better-sqlite3": "^7.6.13",
-    "@types/node": "^24.12.2",
     "electron": "^41.5.0",
     "electron-builder": "^26.8.1",
-    "vite": "^8.0.10",
-    "vitest": "^4.1.5"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
+    "vite": "^8.0.10"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,7 +43,6 @@
     "@tanstack/devtools-vite": "^0.6.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
@@ -52,14 +51,6 @@
     "jsdom": "^29.1.1",
     "oxlint": "^1.63.0",
     "vite": "^8.0.10",
-    "vitest": "^4.1.5",
     "web-vitals": "^5.2.0"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,13 @@
     "check": "pnpm run typecheck && oxlint --fix && oxfmt"
   },
   "devDependencies": {
+    "@types/node": "^24.12.2",
     "@typescript/native-preview": "7.0.0-dev.20260508.1",
     "oxfmt": "^0.48.0",
-    "oxlint": "^1.63.0"
+    "oxlint": "^1.63.0",
+    "tsdown": "^0.21.10",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/ai-chat-session/package.json
+++ b/packages/ai-chat-session/package.json
@@ -16,16 +16,5 @@
   "dependencies": {
     "@repo/ai-chat": "workspace:*",
     "@repo/async-queue": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/node": "^24.12.2",
-    "vitest": "^4.1.5"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -28,16 +28,5 @@
     "@tanstack/ai-ollama": "^0.6.10",
     "@tanstack/ai-react": "^0.8.0",
     "zod": "^4.4.3"
-  },
-  "devDependencies": {
-    "@types/node": "^24.12.2",
-    "tsdown": "^0.21.10"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/ai-tools/package.json
+++ b/packages/ai-tools/package.json
@@ -21,18 +21,7 @@
     "@tanstack/ai": "^0.14.0",
     "zod": "^4.4.3"
   },
-  "devDependencies": {
-    "@types/node": "^24.12.2",
-    "tsdown": "^0.21.10"
-  },
   "peerDependencies": {
     "electron": "^41.2.1"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/async-queue/package.json
+++ b/packages/async-queue/package.json
@@ -11,12 +11,5 @@
   },
   "scripts": {
     "typecheck": "tsgo --noEmit"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,16 +15,5 @@
   },
   "dependencies": {
     "@repo/sqlite": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/node": "^24.12.2",
-    "vitest": "^4.1.5"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/deep-merge/package.json
+++ b/packages/deep-merge/package.json
@@ -12,16 +12,5 @@
   "scripts": {
     "test": "tsgo --noEmit && vitest run",
     "typecheck": "tsgo --noEmit"
-  },
-  "devDependencies": {
-    "@types/node": "^24.12.2",
-    "vitest": "^4.1.5"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/frame-rpc/package.json
+++ b/packages/frame-rpc/package.json
@@ -11,15 +11,5 @@
   },
   "scripts": {
     "typecheck": "tsgo --noEmit"
-  },
-  "devDependencies": {
-    "@types/node": "^24.12.2"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/ipc/package.json
+++ b/packages/ipc/package.json
@@ -22,14 +22,6 @@
     "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
-    "electron": "^41.5.0",
-    "vitest": "^4.1.5"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
+    "electron": "^41.5.0"
   }
 }

--- a/packages/mcp-server-example/package.json
+++ b/packages/mcp-server-example/package.json
@@ -18,17 +18,9 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/express": "^5.0.6",
-    "@types/node": "^24.12.2"
+    "@types/express": "^5.0.6"
   },
   "peerDependencies": {
     "electron": "^41.2.1"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -15,16 +15,5 @@
   },
   "dependencies": {
     "ollama": "^0.6.3"
-  },
-  "devDependencies": {
-    "@types/node": "^24.12.2",
-    "vitest": "^4.1.5"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -85,14 +85,6 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "vite": "^8.0.10",
-    "vitest": "^4.1.5"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
+    "vite": "^8.0.10"
   }
 }

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -11,12 +11,5 @@
   },
   "scripts": {
     "typecheck": "tsgo --noEmit"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/tanstack-ai-mcp/package.json
+++ b/packages/tanstack-ai-mcp/package.json
@@ -15,15 +15,5 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@tanstack/ai": "^0.14.0"
-  },
-  "devDependencies": {
-    "@types/node": "^24.12.2"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.1.2",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,6 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
     "globals": "^17.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.3
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260508.1
         version: 7.0.0-dev.20260508.1
@@ -216,6 +219,15 @@ importers:
       oxlint:
         specifier: ^1.63.0
         version: 1.63.0
+      tsdown:
+        specifier: ^0.21.10
+        version: 0.21.10(@typescript/native-preview@7.0.0-dev.20260508.1)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
 
   apps/api:
     dependencies:
@@ -274,9 +286,6 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
       electron:
         specifier: ^41.5.0
         version: 41.5.1
@@ -286,9 +295,6 @@ importers:
       vite:
         specifier: ^8.0.10
         version: 8.0.11(@types/node@24.12.3)(jiti@2.7.0)
-      vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
 
   apps/web:
     dependencies:
@@ -386,9 +392,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -413,9 +416,6 @@ importers:
       vite:
         specifier: ^8.0.10
         version: 8.0.11(@types/node@24.12.3)(jiti@2.7.0)
-      vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
       web-vitals:
         specifier: ^5.2.0
         version: 5.2.0
@@ -437,13 +437,6 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
-      tsdown:
-        specifier: ^0.21.10
-        version: 0.21.10(@typescript/native-preview@7.0.0-dev.20260508.1)
 
   packages/ai-chat-session:
     dependencies:
@@ -453,13 +446,6 @@ importers:
       '@repo/async-queue':
         specifier: workspace:*
         version: link:../async-queue
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
-      vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
 
   packages/ai-tools:
     dependencies:
@@ -475,13 +461,6 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
-      tsdown:
-        specifier: ^0.21.10
-        version: 0.21.10(@typescript/native-preview@7.0.0-dev.20260508.1)
 
   packages/async-queue: {}
 
@@ -490,37 +469,16 @@ importers:
       '@repo/sqlite':
         specifier: workspace:*
         version: link:../sqlite
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
-      vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
 
-  packages/deep-merge:
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
-      vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
+  packages/deep-merge: {}
 
-  packages/frame-rpc:
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
+  packages/frame-rpc: {}
 
   packages/ipc:
     devDependencies:
       electron:
         specifier: ^41.5.0
         version: 41.5.1
-      vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.11(@types/node@25.9.1)(jiti@2.7.0))
 
   packages/mcp-server-example:
     dependencies:
@@ -540,22 +498,12 @@ importers:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
 
   packages/rag:
     dependencies:
       ollama:
         specifier: ^0.6.3
         version: 0.6.3
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
-      vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
 
   packages/shadcn:
     dependencies:
@@ -652,10 +600,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       vite:
         specifier: ^8.0.10
-        version: 8.0.11(@types/node@25.9.1)(jiti@2.7.0)
-      vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.11(@types/node@25.9.1)(jiti@2.7.0))
+        version: 8.0.11(@types/node@24.12.3)(jiti@2.7.0)
 
   packages/sqlite: {}
 
@@ -667,10 +612,6 @@ importers:
       '@tanstack/ai':
         specifier: ^0.14.0
         version: 0.14.0
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.2
-        version: 24.12.3
 
   packages/ui:
     dependencies:
@@ -727,7 +668,7 @@ importers:
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
       shadcn:
         specifier: ^4.8.0
-        version: 4.8.0(@types/node@25.9.1)
+        version: 4.8.0(@types/node@24.12.3)(typescript@6.0.3)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -744,9 +685,6 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
-      '@types/node':
-        specifier: ^25.1.0
-        version: 25.9.1
       '@types/react':
         specifier: ^19.2.10
         version: 19.2.14
@@ -3128,9 +3066,6 @@ packages:
 
   '@types/node@24.12.3':
     resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
-
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/plist@3.0.5':
     resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
@@ -6066,14 +6001,16 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
@@ -6969,14 +6906,6 @@ snapshots:
       '@inquirer/type': 4.0.5(@types/node@24.12.3)
     optionalDependencies:
       '@types/node': 24.12.3
-    optional: true
-
-  '@inquirer/confirm@6.0.13(@types/node@25.9.1)':
-    dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
-    optionalDependencies:
-      '@types/node': 25.9.1
 
   '@inquirer/core@11.1.10(@types/node@24.12.3)':
     dependencies:
@@ -6989,30 +6918,12 @@ snapshots:
       signal-exit: 4.1.0
     optionalDependencies:
       '@types/node': 24.12.3
-    optional: true
-
-  '@inquirer/core@11.1.10(@types/node@25.9.1)':
-    dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
-      cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.2
-      mute-stream: 3.0.0
-      signal-exit: 4.1.0
-    optionalDependencies:
-      '@types/node': 25.9.1
 
   '@inquirer/figures@2.0.5': {}
 
   '@inquirer/type@4.0.5(@types/node@24.12.3)':
     optionalDependencies:
       '@types/node': 24.12.3
-    optional: true
-
-  '@inquirer/type@4.0.5(@types/node@25.9.1)':
-    optionalDependencies:
-      '@types/node': 25.9.1
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -8757,10 +8668,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.9.1':
-    dependencies:
-      undici-types: 7.24.6
-
   '@types/plist@3.0.5':
     dependencies:
       '@types/node': 24.12.3
@@ -8794,7 +8701,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.12.3
 
   '@types/statuses@2.0.6': {}
 
@@ -8864,23 +8771,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))':
+  '@vitest/mocker@4.1.5(msw@2.14.6(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.14.6(@types/node@24.12.3)
+      msw: 2.14.6(@types/node@24.12.3)(typescript@6.0.3)
       vite: 8.0.11(@types/node@24.12.3)(jiti@2.7.0)
-
-  '@vitest/mocker@4.1.5(msw@2.14.6(@types/node@25.9.1))(vite@8.0.11(@types/node@25.9.1)(jiti@2.7.0))':
-    dependencies:
-      '@vitest/spy': 4.1.5
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.14.6(@types/node@25.9.1)
-      vite: 8.0.11(@types/node@25.9.1)(jiti@2.7.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -9339,12 +9237,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig@9.0.1:
+  cosmiconfig@9.0.1(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   crc@3.8.0:
     dependencies:
@@ -10927,7 +10827,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.14.6(@types/node@24.12.3):
+  msw@2.14.6(@types/node@24.12.3)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.0.13(@types/node@24.12.3)
       '@mswjs/interceptors': 0.41.9
@@ -10947,30 +10847,8 @@ snapshots:
       type-fest: 5.6.0
       until-async: 3.0.2
       yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  msw@2.14.6(@types/node@25.9.1):
-    dependencies:
-      '@inquirer/confirm': 6.0.13(@types/node@25.9.1)
-      '@mswjs/interceptors': 0.41.9
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.0
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.6.0
-      until-async: 3.0.2
-      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -11640,7 +11518,7 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
-  rolldown-plugin-dts@0.23.2(@typescript/native-preview@7.0.0-dev.20260508.1)(rolldown@1.0.0-rc.17):
+  rolldown-plugin-dts@0.23.2(@typescript/native-preview@7.0.0-dev.20260508.1)(rolldown@1.0.0-rc.17)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -11655,6 +11533,7 @@ snapshots:
       rolldown: 1.0.0-rc.17
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260508.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -11804,7 +11683,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.8.0(@types/node@25.9.1):
+  shadcn@4.8.0(@types/node@24.12.3)(typescript@6.0.3):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.3
@@ -11815,7 +11694,7 @@ snapshots:
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.2
       commander: 14.0.3
-      cosmiconfig: 9.0.1
+      cosmiconfig: 9.0.1(typescript@6.0.3)
       dedent: 1.7.2
       deepmerge: 4.3.1
       diff: 8.0.4
@@ -11825,7 +11704,7 @@ snapshots:
       fuzzysort: 3.1.0
       https-proxy-agent: 7.0.6
       kleur: 4.1.5
-      msw: 2.14.6(@types/node@25.9.1)
+      msw: 2.14.6(@types/node@24.12.3)(typescript@6.0.3)
       node-fetch: 3.3.2
       open: 11.0.0
       ora: 8.2.0
@@ -12120,7 +11999,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.21.10(@typescript/native-preview@7.0.0-dev.20260508.1):
+  tsdown@0.21.10(@typescript/native-preview@7.0.0-dev.20260508.1)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -12131,13 +12010,15 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(@typescript/native-preview@7.0.0-dev.20260508.1)(rolldown@1.0.0-rc.17)
+      rolldown-plugin-dts: 0.23.2(@typescript/native-preview@7.0.0-dev.20260508.1)(rolldown@1.0.0-rc.17)(typescript@6.0.3)
       semver: 7.8.0
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
       unrun: 0.2.38
+    optionalDependencies:
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -12170,14 +12051,14 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typescript@6.0.3: {}
+
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
   undici-types@7.16.0: {}
-
-  undici-types@7.24.6: {}
 
   undici@6.25.0: {}
 
@@ -12328,22 +12209,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vite@8.0.11(@types/node@25.9.1)(jiti@2.7.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.14
-      rolldown: 1.0.0-rc.18
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.9.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-
-  vitest@4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0)):
+  vitest@4.1.5(@types/node@24.12.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.14.6(@types/node@24.12.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
+      '@vitest/mocker': 4.1.5(msw@2.14.6(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -12364,34 +12233,6 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.3
-      jsdom: 29.1.1(@noble/hashes@1.8.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.5(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.11(@types/node@25.9.1)(jiti@2.7.0)):
-    dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.14.6(@types/node@25.9.1))(vite@8.0.11(@types/node@25.9.1)(jiti@2.7.0))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.11(@types/node@25.9.1)(jiti@2.7.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.9.1
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## 概要

- workspace ごとに重複していた開発依存と `devEngines.packageManager` 設定をルートへ集約する
- `.pnpm-store` を `.gitignore` に追加する

## 変更内容

- ルート `package.json` に `@types/node` / `tsdown` / `typescript` / `vitest` を追加
- 各 app/package の `package.json` から重複する `devDependencies` と `devEngines` を削除
- `pnpm-lock.yaml` を依存集約後の解決結果に更新
- `.gitignore` に `.pnpm-store` を追加

## 影響範囲

- pnpm workspace 全体の開発依存解決
- 各 workspace の lint / test / typecheck / build 実行環境
- `devEngines.packageManager` の設定箇所が各 workspace からルートへ変わる

## 動作確認

- [x] `pnpm test` が成功する
- [x] `pnpm dev` で起動できる
- [x] `pnpm build` でビルドして .app を起動できる

## レビュー観点

- ルートへ集約した開発依存で各 workspace の script が問題なく動作するか
- `@types/node` のバージョン統一により型解決へ意図しない影響がないか
- `vitest` / `tsdown` / `typescript` をルート依存にしたことで pnpm の workspace 解決が想定どおりか
- `devEngines.packageManager` をルートだけに残す方針で問題ないか

## 関連リンク

- なし