### PR TITLE
feat: AIチャットに Ollama WebSearch と API キー設定を追加

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@repo/ai-chat": "workspace:*",
     "@repo/ai-chat-session": "workspace:*",
+    "@repo/ai-ollama-tools": "workspace:*",
     "@repo/ai-tools": "workspace:*",
     "@repo/auth": "workspace:*",
     "@repo/deep-merge": "workspace:*",

--- a/apps/api/src/api/aiChat.ts
+++ b/apps/api/src/api/aiChat.ts
@@ -10,6 +10,7 @@ import {
   prepareAiChatSessionForChat,
 } from '@repo/ai-chat-session'
 import type { AiChatSession } from '@repo/ai-chat-session'
+import { webSearchTool } from '@repo/ai-ollama-tools'
 import { clockToolDef } from '@repo/ai-tools/client/definitions'
 import {
   createSearchProjectDetailTool,
@@ -102,6 +103,7 @@ const createChat =
         clockToolDef,
         ...toolsByMcp,
         searchProjectDetailsTool,
+        webSearchTool,
       ]
     }
 

--- a/apps/api/src/api/aiChat.ts
+++ b/apps/api/src/api/aiChat.ts
@@ -10,7 +10,7 @@ import {
   prepareAiChatSessionForChat,
 } from '@repo/ai-chat-session'
 import type { AiChatSession } from '@repo/ai-chat-session'
-import { webSearchTool } from '@repo/ai-ollama-tools'
+import { createWebSearchTool } from '@repo/ai-ollama-tools'
 import { clockToolDef } from '@repo/ai-tools/client/definitions'
 import {
   createSearchProjectDetailTool,
@@ -30,6 +30,7 @@ export type AiChatContext = {
   getSearchProjectDetailDbPath: () => string
   getAiChatSession: () => AiChatSession | null
   setAiChatSession: (session: AiChatSession | null) => void
+  getApiKey: (provider: 'ollama') => Promise<string | undefined>
 }
 
 // -----------------------------------------------------------------------------
@@ -53,8 +54,13 @@ export type AiChatApi = ApiInterface<{
 const createChat =
   <TKey>(getContext: (key: TKey) => AiChatContext): WithCallerKey<AiChatApi['chat'], TKey> =>
   async (request, key) => {
-    const { getToolsByMcp, getSearchProjectDetailDbPath, getAiChatSession, setAiChatSession } =
-      getContext(key)
+    const {
+      getToolsByMcp,
+      getSearchProjectDetailDbPath,
+      getAiChatSession,
+      setAiChatSession,
+      getApiKey,
+    } = getContext(key)
     const { messages, data, id } = request
 
     const sessionStore = {
@@ -97,6 +103,7 @@ const createChat =
         queryPrefix: 'search_query:',
         topK: 6,
       })
+      const webSearchTool = createWebSearchTool(() => getApiKey('ollama'))
       return [
         switchThemeDarkTool,
         switchThemeLightTool,

--- a/apps/desktop/src/main/api/ai-chat.ts
+++ b/apps/desktop/src/main/api/ai-chat.ts
@@ -36,5 +36,17 @@ export const createAiChatContext: CreateApiContext<AiChatContext> = ({
     setAiChatSession: (session) => {
       windowState.aiChatSession = session
     },
+    getApiKey: async (provider) => {
+      if (provider === 'ollama') {
+        try {
+          return await appRuntime.secretStorage.retrieveSecret('OLLAMA_API_KEY')
+        } catch {
+          appRuntime.logger.warn('OLLAMA_API_KEY is not set in secret storage')
+          return undefined
+        }
+      }
+
+      return undefined
+    },
   }
 }

--- a/apps/web/src/routes/(app)/settings.tsx
+++ b/apps/web/src/routes/(app)/settings.tsx
@@ -238,7 +238,9 @@ function SetSecretRow() {
 
   return (
     <div className="space-y-2">
-      <Label htmlFor="secret">FOO_API_KEY を保存（保存した値を再表示することはできません）</Label>
+      <Label htmlFor="secret">
+        OLLAMA_API_KEY を保存（保存した値を再表示することはできません）
+      </Label>
       <Input
         id="secret"
         type="password"
@@ -248,8 +250,8 @@ function SetSecretRow() {
       />
       <div className="flex justify-end">
         <Button
-          onClick={() => {
-            secret.setSecret({ key: 'FOO_API_KEY', value: secretValue })
+          onClick={async () => {
+            await secret.setSecret({ key: 'OLLAMA_API_KEY', value: secretValue })
             setSecretValue('')
           }}
           disabled={!secretValue.trim()}

--- a/packages/ai-chat/src/chat.ts
+++ b/packages/ai-chat/src/chat.ts
@@ -7,6 +7,8 @@ import { isOllamaModelMessage } from './ollama/ollama'
 import type { OllamaModelMessage } from './ollama/ollama'
 import type { ChatRequest, OnChunk, OnDone, OnError } from './types'
 
+const SYSTEM_PROMPT = `このメッセージはSystem Promptとして扱ってください。あなたは自分の知識にないことを推測で答えてはいけません。知らないことはWebSearchツールを使って調べてから回答しなくてはいけません。WebSearchツールが使えない場合にはあなたは知らないと答えなくてはなりません。`
+
 export async function chat(options: {
   request: ChatRequest
   onChunk?: OnChunk
@@ -63,6 +65,7 @@ export async function chat(options: {
       messages: filteredModelMessages,
       tools,
       stream: true,
+      systemPrompts: [SYSTEM_PROMPT],
     })
 
     /** ------------------------------------------------------------------------

--- a/packages/ai-ollama-tools/example/index.ts
+++ b/packages/ai-ollama-tools/example/index.ts
@@ -1,4 +1,4 @@
-import { webSearchTool } from '../dist/index.mjs'
+import { createWebSearchTool } from '../dist/index.mjs'
 
 const query = process.argv[2] ?? ''
 
@@ -10,7 +10,7 @@ if (query.trim().length === 0) {
 
 console.log(`Searching for: ${query}`)
 
-const webSearch = webSearchTool.execute
+const webSearch = createWebSearchTool().execute
 
 if (!webSearch) {
   console.log('webSearch is not available')

--- a/packages/ai-ollama-tools/example/index.ts
+++ b/packages/ai-ollama-tools/example/index.ts
@@ -1,0 +1,21 @@
+import { webSearchTool } from '../dist/index.mjs'
+
+const query = process.argv[2] ?? ''
+
+if (query.trim().length === 0) {
+  console.log('Query is required')
+  console.log('Example: pnpm run example hello')
+  process.exit(0)
+}
+
+console.log(`Searching for: ${query}`)
+
+const webSearch = webSearchTool.execute
+
+if (!webSearch) {
+  console.log('webSearch is not available')
+  process.exit(0)
+}
+
+const result = await webSearch({ query, maxResults: 1 })
+console.log(result)

--- a/packages/ai-ollama-tools/package.json
+++ b/packages/ai-ollama-tools/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@repo/ai-ollama-tools",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "build": "tsdown src/index.ts",
+    "example": "node example/index.ts"
+  },
+  "dependencies": {
+    "@repo/rag": "workspace:*",
+    "@tanstack/ai": "^0.29.0",
+    "ollama": "^0.6.3",
+    "zod": "^4.4.3"
+  },
+  "//": {
+    "how to run example": "export OLLAMA_API_KEY=your_api_key && pnpm run example <keyword>"
+  }
+}

--- a/packages/ai-ollama-tools/src/definition.ts
+++ b/packages/ai-ollama-tools/src/definition.ts
@@ -1,0 +1,20 @@
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+export const webSearchToolDef = toolDefinition({
+  name: 'webSearch',
+  description: 'Perform a web search and return the results',
+  inputSchema: z.object({
+    query: z.string(),
+    maxResults: z.int().min(1).max(10).optional(),
+  }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      url: z.string(),
+      content: z.string(),
+      source: z.string(),
+    }),
+  ),
+})

--- a/packages/ai-ollama-tools/src/index.ts
+++ b/packages/ai-ollama-tools/src/index.ts
@@ -1,0 +1,2 @@
+export * from './tools'
+export * from './definition'

--- a/packages/ai-ollama-tools/src/tools.ts
+++ b/packages/ai-ollama-tools/src/tools.ts
@@ -1,8 +1,10 @@
 import { webSearchToolDef } from './definition'
-import { webSearch } from './web-search'
+import { createWebSearch } from './web-search'
 
-export const webSearchTool = webSearchToolDef.server(async (args) => {
-  const { query, maxResults } = args
-  const results = await webSearch({ query, maxResults })
-  return results
-})
+export const createWebSearchTool = (apiKey?: string | (() => Promise<string | undefined>)) =>
+  webSearchToolDef.server(async (args) => {
+    const { query, maxResults } = args
+    const webSearch = createWebSearch(apiKey)
+    const results = await webSearch({ query, maxResults })
+    return results
+  })

--- a/packages/ai-ollama-tools/src/tools.ts
+++ b/packages/ai-ollama-tools/src/tools.ts
@@ -1,0 +1,8 @@
+import { webSearchToolDef } from './definition'
+import { webSearch } from './web-search'
+
+export const webSearchTool = webSearchToolDef.server(async (args) => {
+  const { query, maxResults } = args
+  const results = await webSearch({ query, maxResults })
+  return results
+})

--- a/packages/ai-ollama-tools/src/web-search.ts
+++ b/packages/ai-ollama-tools/src/web-search.ts
@@ -3,8 +3,6 @@ import { Ollama } from 'ollama'
 export type WebSearchInput = {
   query: string
   maxResults?: number
-  /** Ollama APIキー `OLLAMA_API_KEY` */
-  apiKey?: string
 }
 
 export type WebSearchResult = {
@@ -16,36 +14,59 @@ export type WebSearchResult = {
 }
 
 /**
- * Web検索を実行し、結果を返します。
+ * OllamaのWeb検索ツールを作成します。
  *
- * https://docs.ollama.com/capabilities/web-search
- *
- * @param input 検索クエリと最大結果数を指定します。
- * @returns 検索結果の配列を返します。
+ * @param apiKey Ollama APIキー。環境変数 `OLLAMA_API_KEY` からも取得されます。
+ * @returns Web検索を実行する関数を返します。
  */
-export async function webSearch(input: WebSearchInput): Promise<WebSearchResult[]> {
-  const { query, maxResults = 5, apiKey } = input
+export function createWebSearch(apiKey?: string | (() => Promise<string | undefined>)) {
+  /**
+   * Web検索を実行し、結果を返します。
+   *
+   * https://docs.ollama.com/capabilities/web-search
+   *
+   * @param input 検索クエリと最大結果数を指定します。
+   * @returns 検索結果の配列を返します。
+   */
+  async function webSearch(input: WebSearchInput): Promise<WebSearchResult[]> {
+    const { query, maxResults = 5 } = input
 
-  const ollama = new Ollama({
-    host: 'https://ollama.com',
-    headers: { Authorization: 'Bearer ' + (apiKey ?? process.env.OLLAMA_API_KEY) },
-  })
+    let resolvedApiKey: string | undefined = undefined
+    if (typeof apiKey === 'string') {
+      resolvedApiKey = apiKey
+    } else if (typeof apiKey === 'function') {
+      resolvedApiKey = await apiKey()
+    } else {
+      resolvedApiKey = process.env.OLLAMA_API_KEY
+    }
 
-  const results = await ollama.webSearch({
-    query,
-    // @ts-expect-error ollama apiの型と実装が一致していない
-    // https://github.com/ollama/ollama-js/issues/283
-    // https://github.com/ollama/ollama-js/pull/284
-    max_results: Math.min(maxResults, 10),
-  })
+    if (typeof resolvedApiKey !== 'string' || resolvedApiKey.trim() === '') {
+      throw new Error('OLLAMA_API_KEY is not set')
+    }
 
-  return results.results.map((result, i) => ({
-    id: `result_${i}`,
-    // @ts-expect-error ollama apiの型と実装が一致していない
-    title: result.title ?? 'UNKNOWN',
-    // @ts-expect-error ollama apiの型と実装が一致していない
-    url: result.url ?? 'UNKNOWN',
-    content: result.content,
-    source: 'ollama web search',
-  }))
+    const ollama = new Ollama({
+      host: 'https://ollama.com',
+      headers: { Authorization: 'Bearer ' + resolvedApiKey },
+    })
+
+    const results = await ollama.webSearch({
+      query,
+      // @ts-expect-error ollama apiの型と実装が一致していない
+      // https://github.com/ollama/ollama-js/issues/283
+      // https://github.com/ollama/ollama-js/pull/284
+      max_results: Math.min(maxResults, 10),
+    })
+
+    return results.results.map((result, i) => ({
+      id: `result_${i}`,
+      // @ts-expect-error ollama apiの型と実装が一致していない
+      title: result.title ?? 'UNKNOWN',
+      // @ts-expect-error ollama apiの型と実装が一致していない
+      url: result.url ?? 'UNKNOWN',
+      content: result.content,
+      source: 'ollama web search',
+    }))
+  }
+
+  return webSearch
 }

--- a/packages/ai-ollama-tools/src/web-search.ts
+++ b/packages/ai-ollama-tools/src/web-search.ts
@@ -1,0 +1,51 @@
+import { Ollama } from 'ollama'
+
+export type WebSearchInput = {
+  query: string
+  maxResults?: number
+  /** Ollama APIキー `OLLAMA_API_KEY` */
+  apiKey?: string
+}
+
+export type WebSearchResult = {
+  id: string
+  title: string
+  url: string
+  content: string
+  source: string
+}
+
+/**
+ * Web検索を実行し、結果を返します。
+ *
+ * https://docs.ollama.com/capabilities/web-search
+ *
+ * @param input 検索クエリと最大結果数を指定します。
+ * @returns 検索結果の配列を返します。
+ */
+export async function webSearch(input: WebSearchInput): Promise<WebSearchResult[]> {
+  const { query, maxResults = 5, apiKey } = input
+
+  const ollama = new Ollama({
+    host: 'https://ollama.com',
+    headers: { Authorization: 'Bearer ' + (apiKey ?? process.env.OLLAMA_API_KEY) },
+  })
+
+  const results = await ollama.webSearch({
+    query,
+    // @ts-expect-error ollama apiの型と実装が一致していない
+    // https://github.com/ollama/ollama-js/issues/283
+    // https://github.com/ollama/ollama-js/pull/284
+    max_results: Math.min(maxResults, 10),
+  })
+
+  return results.results.map((result, i) => ({
+    id: `result_${i}`,
+    // @ts-expect-error ollama apiの型と実装が一致していない
+    title: result.title ?? 'UNKNOWN',
+    // @ts-expect-error ollama apiの型と実装が一致していない
+    url: result.url ?? 'UNKNOWN',
+    content: result.content,
+    source: 'ollama web search',
+  }))
+}

--- a/packages/ai-ollama-tools/tsconfig.json
+++ b/packages/ai-ollama-tools/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "include": ["src/**/*.ts"],
+
+  "compilerOptions": {
+    "target": "ES2022",
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+
+    /* Linting */
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       '@repo/ai-chat-session':
         specifier: workspace:*
         version: link:../../packages/ai-chat-session
+      '@repo/ai-ollama-tools':
+        specifier: workspace:*
+        version: link:../../packages/ai-ollama-tools
       '@repo/ai-tools':
         specifier: workspace:*
         version: link:../../packages/ai-tools
@@ -468,6 +471,21 @@ importers:
       '@repo/async-queue':
         specifier: workspace:*
         version: link:../async-queue
+
+  packages/ai-ollama-tools:
+    dependencies:
+      '@repo/rag':
+        specifier: workspace:*
+        version: link:../rag
+      '@tanstack/ai':
+        specifier: ^0.29.0
+        version: 0.29.0
+      ollama:
+        specifier: ^0.6.3
+        version: 0.6.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/ai-tools:
     dependencies:


### PR DESCRIPTION
## 概要

- AIチャットから利用する Ollama の WebSearch ツールを追加しました。
- 設定画面と desktop 側で OLLAMA_API_KEY の保存・取得を配線しました。

## 変更内容

- packages/ai-ollama-tools を新規追加し、WebSearch の定義、実行処理、公開エントリ、example を実装
- apps/api に新規 package 依存を追加し、AIチャットのツール一覧へ webSearch を組み込み
- apps/desktop で secretStorage から OLLAMA_API_KEY を取得する処理を追加
- apps/web の設定画面で保存する secret key を OLLAMA_API_KEY に変更
- packages/ai-chat に system prompt を追加し、未知の情報は WebSearch を使って調べる前提を明示

## 影響範囲

- AIチャットのツール実行経路全体
- 設定画面の API キー保存仕様
- ollama.com への外部 WebSearch 呼び出し

## 動作確認

- [x] pnpm test が成功する
- [x] pnpm dev で起動できる
- [x] pnpm build でビルドして .app / ~~.exe~~ を起動できる

## レビュー観点

- OLLAMA_API_KEY 未設定時に AIチャットのエラー処理が期待どおりか
- Ollama SDK の型不整合を @ts-expect-error で吸収している箇所の妥当性
- テストファイルや CI 設定の変更は差分上なく、新規 WebSearch 実装の自動テストは未追加です

## 関連リンク

- なし