### PR TITLE
feat: チャットにテキスト添付ファイル送信を追加

### DIFF
--- a/apps/web/src/features/chat/components/chat-session-provider.tsx
+++ b/apps/web/src/features/chat/components/chat-session-provider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { clientTools } from '@tanstack/ai-client'
-import type { UIMessage } from '@tanstack/ai-client'
+import type { MultimodalContent, UIMessage } from '@tanstack/ai-client'
 import { useChat } from '@tanstack/ai-react'
 
 import { aiChatAdapter } from '@repo/ai-chat/react-adapter'
@@ -16,7 +16,7 @@ type ChatSessionValue = {
   // ツールのジェネリクスをアプリ全体に配管することなく変更できるように、
   // これらは意図的に広く保ちます。
   messages: Array<UIMessage>
-  sendMessage: (content: string) => Promise<void>
+  sendMessage: (content: string | MultimodalContent) => Promise<void>
   isLoading: boolean
   stop: () => void
   status: ReturnType<typeof useChat>['status']
@@ -77,7 +77,7 @@ export function ChatSessionProvider(props: ChatSessionProviderProps) {
       input,
       setInput,
       messages: chat.messages as Array<UIMessage>,
-      sendMessage: chat.sendMessage as (content: string) => Promise<void>,
+      sendMessage: chat.sendMessage,
       isLoading: chat.isLoading,
       stop: chat.stop,
       status: chat.status,

--- a/apps/web/src/features/chat/components/chat.tsx
+++ b/apps/web/src/features/chat/components/chat.tsx
@@ -1,7 +1,16 @@
+import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
 import type { AnyClientTool, MessagePart } from '@tanstack/ai-client'
-import { ArrowUpIcon, BotIcon, SquareIcon, User2Icon } from 'lucide-react'
+import {
+  ArrowUpIcon,
+  BotIcon,
+  FileTextIcon,
+  PlusIcon,
+  SquareIcon,
+  User2Icon,
+  XIcon,
+} from 'lucide-react'
 import remarkGfm from 'remark-gfm'
 
 import {
@@ -21,6 +30,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@repo/ui/components/alert-dialog'
+import { Button } from '@repo/ui/components/button'
 import { Field } from '@repo/ui/components/field'
 import {
   InputGroup,
@@ -32,6 +42,13 @@ import { Separator } from '@repo/ui/components/separator'
 
 import { useAuth } from '@/features/auth/api/auth'
 import { useChatSession } from '@/features/chat/components/chat-session-provider'
+import {
+  isChatAttachmentTextPart,
+  useChatAttachment,
+} from '@/features/chat/hooks/use-chat-attachment'
+import type { ChatAttachmentMetadata } from '@/features/chat/hooks/use-chat-attachment'
+import { formatBytes } from '@/features/chat/utils/format-bytes'
+import { loadChatAttachmentFromFileSystem } from '@/features/chat/utils/load-chat-attachment-from-file-system'
 import { useAutoScrollToBottom } from '@/hooks/use-auto-scroll-to-bottom'
 
 export function Chat() {
@@ -45,6 +62,15 @@ export function Chat() {
 
   const { scrollContainerRef, scrollBottomRef, onScroll } = useAutoScrollToBottom([messages])
 
+  const {
+    attachmentFile,
+    attachmentError,
+    selectAttachment,
+    clearAttachment,
+    clearAttachmentError,
+    createAttachmentMessagePart,
+  } = useChatAttachment({ loadAttachment: loadChatAttachmentFromFileSystem })
+
   const send = () => {
     if (isLoading) {
       // 生成中に送信された場合は、生成停止とみなす
@@ -54,7 +80,24 @@ export function Chat() {
       if (!input.trim()) {
         return
       }
-      sendMessage(input)
+
+      if (attachmentFile) {
+        clearAttachmentError()
+        sendMessage({
+          content: [
+            {
+              type: 'text',
+              content: input,
+            },
+            createAttachmentMessagePart(attachmentFile),
+          ],
+        })
+        clearAttachment()
+      } else {
+        clearAttachmentError()
+        sendMessage(input)
+      }
+
       setInput('')
     }
   }
@@ -73,6 +116,7 @@ export function Chat() {
   }
 
   const disabled = status === 'ready' && !input.trim()
+  const disabledAttachment = isLoading || isNotAvailable
 
   return (
     <div className="flex min-h-0 flex-1 flex-col w-full gap-4">
@@ -114,6 +158,25 @@ export function Chat() {
 
       <form onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
         <Field>
+          {attachmentFile ? (
+            <div className="mb-2 flex min-w-0 items-center gap-2 rounded border border-border bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
+              <FileTextIcon className="size-3.5 shrink-0" />
+              <span className="truncate">{attachmentFile.name}</span>
+              <span className="shrink-0">{formatBytes(attachmentFile.size)}</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="ml-auto"
+                onClick={clearAttachment}
+              >
+                <XIcon />
+              </Button>
+            </div>
+          ) : null}
+          {attachmentError ? (
+            <div className="mb-2 text-xs text-destructive">{attachmentError}</div>
+          ) : null}
           <InputGroup>
             <InputGroupTextarea
               id="textarea-comment-31"
@@ -131,12 +194,20 @@ export function Chat() {
               onChange={(e) => setInput(e.target.value)}
               disabled={isLoading || isNotAvailable}
             />
-            <InputGroupAddon align="block-end">
+            <InputGroupAddon align="block-end" className="justify-between">
+              <InputGroupButton
+                variant="outline"
+                size="sm"
+                type="button"
+                disabled={disabledAttachment}
+                onClick={selectAttachment}
+              >
+                <PlusIcon className="fill-primary-foreground" />
+              </InputGroupButton>
               <InputGroupButton
                 variant="default"
                 size="sm"
                 type="submit"
-                className="ml-auto"
                 disabled={disabled || isNotAvailable}
               >
                 {isLoading ? <SquareIcon className="fill-primary-foreground" /> : <ArrowUpIcon />}
@@ -160,6 +231,10 @@ function MessagePart<TTools extends ReadonlyArray<AnyClientTool> = any, TData = 
 
   switch (part.type) {
     case 'text':
+      if (isChatAttachmentTextPart(part)) {
+        return <AttachmentPart metadata={part.metadata} />
+      }
+
       return (
         <div>
           <TextContent content={part.content} />
@@ -219,6 +294,16 @@ function MessagePart<TTools extends ReadonlyArray<AnyClientTool> = any, TData = 
     default:
       return <div>Unknown part type: {(part as any).type}</div>
   }
+}
+
+function AttachmentPart({ metadata }: { metadata: ChatAttachmentMetadata }) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded border border-border bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
+      <FileTextIcon className="size-3.5 shrink-0" />
+      <span className="truncate">{metadata.name}</span>
+      <span className="shrink-0">{formatBytes(metadata.size)}</span>
+    </div>
+  )
 }
 
 function TextContent({ content }: { content: string }) {

--- a/apps/web/src/features/chat/components/chat.tsx
+++ b/apps/web/src/features/chat/components/chat.tsx
@@ -1,5 +1,6 @@
 import ReactMarkdown from 'react-markdown'
 
+import type { AnyClientTool, MessagePart } from '@tanstack/ai-client'
 import { ArrowUpIcon, BotIcon, SquareIcon, User2Icon } from 'lucide-react'
 import remarkGfm from 'remark-gfm'
 
@@ -101,78 +102,9 @@ export function Chat() {
             <Separator />
 
             <div className="p-2 flex flex-col gap-1">
-              {msg.parts.map((part, idx) => {
-                const key = `${part.type}-${idx}`
-
-                switch (part.type) {
-                  case 'text':
-                    return (
-                      <div key={key}>
-                        <TextContent content={part.content} />
-                      </div>
-                    )
-                  case 'thinking':
-                    return (
-                      <Accordion
-                        type="single"
-                        collapsible
-                        className="italic bg-muted text-muted-foreground overflow-auto"
-                        key={key}
-                      >
-                        <AccordionItem value={key}>
-                          <AccordionTrigger>Thinking</AccordionTrigger>
-                          <AccordionContent className="h-fit">{part.content}</AccordionContent>
-                        </AccordionItem>
-                      </Accordion>
-                    )
-                  case 'tool-call':
-                    return (
-                      <Accordion
-                        type="single"
-                        collapsible
-                        className="italic bg-muted text-muted-foreground overflow-auto"
-                        key={key}
-                      >
-                        <AccordionItem value={key}>
-                          <AccordionTrigger>Tool Call: {part.name}</AccordionTrigger>
-                          <AccordionContent>
-                            <pre className="font-mono not-italic">
-                              {JSON.stringify(part, null, 2)}
-                            </pre>
-                          </AccordionContent>
-                        </AccordionItem>
-                      </Accordion>
-                    )
-                  case 'tool-result':
-                    return (
-                      <Accordion
-                        type="single"
-                        collapsible
-                        className="italic bg-muted text-muted-foreground overflow-auto"
-                        key={key}
-                      >
-                        <AccordionItem value={key}>
-                          <AccordionTrigger>Tool Result</AccordionTrigger>
-                          <AccordionContent>
-                            <pre className="font-mono not-italic">
-                              {JSON.stringify(part, null, 2)}
-                            </pre>
-                          </AccordionContent>
-                        </AccordionItem>
-                      </Accordion>
-                    )
-                  case 'image':
-                    return <div key={key}>Not Implemented</div>
-                  case 'document':
-                    return <div key={key}>Not Implemented</div>
-                  case 'audio':
-                    return <div key={key}>Not Implemented</div>
-                  case 'video':
-                    return <div key={key}>Not Implemented</div>
-                  default:
-                    return <div key={key}>Unknown part type: {(part as any).type}</div>
-                }
-              })}
+              {msg.parts.map((part, idx) => (
+                <MessagePart key={`${part.type}-${idx}`} part={part} idx={idx} />
+              ))}
             </div>
           </div>
         ))}
@@ -215,6 +147,78 @@ export function Chat() {
       </form>
     </div>
   )
+}
+
+function MessagePart<TTools extends ReadonlyArray<AnyClientTool> = any, TData = unknown>({
+  part,
+  idx,
+}: {
+  part: MessagePart<TTools, TData>
+  idx: number
+}) {
+  const key = `${part.type}-${idx}`
+
+  switch (part.type) {
+    case 'text':
+      return (
+        <div>
+          <TextContent content={part.content} />
+        </div>
+      )
+    case 'thinking':
+      return (
+        <Accordion
+          type="single"
+          collapsible
+          className="italic bg-muted text-muted-foreground overflow-auto"
+        >
+          <AccordionItem value={key}>
+            <AccordionTrigger>Thinking</AccordionTrigger>
+            <AccordionContent className="h-fit">{part.content}</AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )
+    case 'tool-call':
+      return (
+        <Accordion
+          type="single"
+          collapsible
+          className="italic bg-muted text-muted-foreground overflow-auto"
+        >
+          <AccordionItem value={key}>
+            <AccordionTrigger>Tool Call: {part.name}</AccordionTrigger>
+            <AccordionContent>
+              <pre className="font-mono not-italic">{JSON.stringify(part, null, 2)}</pre>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )
+    case 'tool-result':
+      return (
+        <Accordion
+          type="single"
+          collapsible
+          className="italic bg-muted text-muted-foreground overflow-auto"
+        >
+          <AccordionItem value={key}>
+            <AccordionTrigger>Tool Result</AccordionTrigger>
+            <AccordionContent>
+              <pre className="font-mono not-italic">{JSON.stringify(part, null, 2)}</pre>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )
+    case 'image':
+      return <div>Not Implemented</div>
+    case 'document':
+      return <div>Not Implemented</div>
+    case 'audio':
+      return <div>Not Implemented</div>
+    case 'video':
+      return <div>Not Implemented</div>
+    default:
+      return <div>Unknown part type: {(part as any).type}</div>
+  }
 }
 
 function TextContent({ content }: { content: string }) {

--- a/apps/web/src/features/chat/hooks/use-chat-attachment.test.tsx
+++ b/apps/web/src/features/chat/hooks/use-chat-attachment.test.tsx
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MessagePart } from '@tanstack/ai-client'
+import { act, renderHook } from '@testing-library/react'
+
+import {
+  createChatAttachmentMessagePart,
+  getAttachmentErrorMessage,
+  isAllowedChatAttachment,
+  isChatAttachmentTextPart,
+  useChatAttachment,
+} from '@/features/chat/hooks/use-chat-attachment'
+import type { ChatAttachment, LoadChatAttachment } from '@/features/chat/hooks/use-chat-attachment'
+
+describe('useChatAttachment', () => {
+  // -----------------------------------------------------------------------------------------------
+  // 添付ファイルの選択が成功した場合、attachmentFile に選択された添付ファイルが格納されることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it('stores a selected attachment', async () => {
+    const attachment = createAttachment()
+    const loadAttachment = vi
+      .fn<LoadChatAttachment>()
+      .mockResolvedValueOnce({ status: 'selected', attachment })
+
+    const { result } = renderHook(() => useChatAttachment({ loadAttachment }))
+
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+
+    expect(loadAttachment).toHaveBeenCalledTimes(1)
+    expect(result.current.attachmentFile).toEqual(attachment)
+    expect(result.current.attachmentError).toBeNull()
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // 選択されたファイルが無効な場合、現在の添付ファイルがクリアされることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it('clears the current attachment when the selected file is invalid', async () => {
+    const attachment = createAttachment()
+    const loadAttachment = vi
+      .fn<LoadChatAttachment>()
+      .mockResolvedValueOnce({ status: 'selected', attachment })
+      .mockResolvedValueOnce({ status: 'invalid' })
+
+    const { result } = renderHook(() => useChatAttachment({ loadAttachment }))
+
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+
+    expect(result.current.attachmentFile).toBeNull()
+    expect(result.current.attachmentError).toBe(getAttachmentErrorMessage())
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // 添付ファイルの読み込みが失敗した場合、現在の添付ファイルは保持され、エラーメッセージが設定されることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it('keeps the current attachment when loading fails', async () => {
+    const attachment = createAttachment()
+    const loadAttachment = vi
+      .fn<LoadChatAttachment>()
+      .mockResolvedValueOnce({ status: 'selected', attachment })
+      .mockResolvedValueOnce({ status: 'failed' })
+
+    const { result } = renderHook(() => useChatAttachment({ loadAttachment }))
+
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+
+    expect(result.current.attachmentFile).toEqual(attachment)
+    expect(result.current.attachmentError).toBe(getAttachmentErrorMessage())
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // 添付ファイルの選択がキャンセルされた場合、現在の添付ファイルは保持され、エラーメッセージはクリアされることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it('keeps the current attachment and clears the error when selection is canceled', async () => {
+    const attachment = createAttachment()
+    const loadAttachment = vi
+      .fn<LoadChatAttachment>()
+      .mockResolvedValueOnce({ status: 'selected', attachment })
+      .mockResolvedValueOnce({ status: 'failed' })
+      .mockResolvedValueOnce({ status: 'canceled' })
+
+    const { result } = renderHook(() => useChatAttachment({ loadAttachment }))
+
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+
+    expect(result.current.attachmentFile).toEqual(attachment)
+    expect(result.current.attachmentError).toBeNull()
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // 予期しないローダーエラーが発生した場合、失敗した読み込みとして扱われることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it('treats unexpected loader errors as failed loads', async () => {
+    const attachment = createAttachment()
+    const loadAttachment = vi
+      .fn<LoadChatAttachment>()
+      .mockResolvedValueOnce({ status: 'selected', attachment })
+      .mockRejectedValueOnce(new Error('unexpected'))
+
+    const { result } = renderHook(() => useChatAttachment({ loadAttachment }))
+
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+
+    expect(result.current.attachmentFile).toEqual(attachment)
+    expect(result.current.attachmentError).toBe(getAttachmentErrorMessage())
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // 添付ファイルとエラーメッセージを同時にクリアできることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it('clears the attachment and error together', async () => {
+    const attachment = createAttachment()
+    const loadAttachment = vi
+      .fn<LoadChatAttachment>()
+      .mockResolvedValueOnce({ status: 'selected', attachment })
+
+    const { result } = renderHook(() => useChatAttachment({ loadAttachment }))
+
+    await act(async () => {
+      await result.current.selectAttachment()
+    })
+    act(() => {
+      result.current.clearAttachment()
+    })
+
+    expect(result.current.attachmentFile).toBeNull()
+    expect(result.current.attachmentError).toBeNull()
+  })
+})
+
+describe('createChatAttachmentMessagePart', () => {
+  // -----------------------------------------------------------------------------------------------
+  // 添付ファイルのテキストパートが正しく作成されることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it('creates the text part used for chat attachments', () => {
+    const attachment = createAttachment({ name: 'note.md', size: 7, content: '# title' })
+
+    expect(createChatAttachmentMessagePart(attachment)).toEqual({
+      type: 'text',
+      content: '\n\n<attachment name="note.md" size="7">\n# title\n</attachment>',
+      metadata: {
+        kind: 'chat-attachment',
+        name: 'note.md',
+        size: 7,
+      },
+    })
+  })
+})
+
+describe('isAllowedChatAttachment', () => {
+  // -----------------------------------------------------------------------------------------------
+  // 添付ファイルの拡張子とサイズが許可されているかどうかを判定する
+  // -----------------------------------------------------------------------------------------------
+  it.each([
+    { file: { isFile: true, extension: '.txt', size: 1024 * 1024 }, expected: true },
+    { file: { isFile: true, extension: '.MD', size: 100 }, expected: true },
+    { file: { isFile: true, extension: '.pdf', size: 100 }, expected: false },
+    { file: { isFile: true, extension: '.txt', size: 1024 * 1024 + 1 }, expected: false },
+    { file: { isFile: false, extension: '.txt', size: 100 }, expected: false },
+  ])('returns $expected for $file.extension size $file.size', ({ file, expected }) => {
+    expect(isAllowedChatAttachment(file)).toBe(expected)
+  })
+})
+
+describe('isChatAttachmentTextPart', () => {
+  // -----------------------------------------------------------------------------------------------
+  // テキストパートがチャット添付ファイルのメタデータを持っているかどうかを判定する
+  // -----------------------------------------------------------------------------------------------
+  it('detects chat attachment metadata on text parts', () => {
+    const attachmentPart = {
+      type: 'text',
+      content: 'hidden attachment prompt',
+      metadata: {
+        kind: 'chat-attachment',
+        name: 'memo.txt',
+        size: 5,
+      },
+    } as MessagePart
+
+    expect(isChatAttachmentTextPart(attachmentPart)).toBe(true)
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // チャット添付ファイルのメタデータを持たないテキストパートは拒否されることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it('rejects non-attachment text parts', () => {
+    expect(isChatAttachmentTextPart({ type: 'text', content: 'hello' } as MessagePart)).toBe(false)
+    expect(
+      isChatAttachmentTextPart({
+        type: 'text',
+        content: 'hello',
+        metadata: {
+          kind: 'other', // 不正な kind
+          name: 'memo.txt',
+          size: 5,
+        },
+      } as MessagePart),
+    ).toBe(false)
+  })
+})
+
+function createAttachment(overrides: Partial<ChatAttachment> = {}): ChatAttachment {
+  return {
+    name: 'memo.txt',
+    size: 5,
+    content: 'hello',
+    ...overrides,
+  }
+}

--- a/apps/web/src/features/chat/hooks/use-chat-attachment.ts
+++ b/apps/web/src/features/chat/hooks/use-chat-attachment.ts
@@ -1,0 +1,167 @@
+import * as React from 'react'
+
+import type { MessagePart } from '@tanstack/ai-client'
+
+import { formatBytes } from '../utils/format-bytes'
+
+const CHAT_ATTACHMENT_METADATA_KIND = 'chat-attachment'
+export const CHAT_ATTACHMENT_MAX_BYTES = 1024 * 1024
+export const CHAT_ATTACHMENT_EXTENSIONS = ['txt', 'md'] as const
+export const CHAT_ATTACHMENT_ALLOWED_EXTENSIONS = CHAT_ATTACHMENT_EXTENSIONS.map(
+  (extension) => `.${extension}`,
+)
+
+export type ChatAttachment = {
+  name: string
+  size: number
+  content: string
+}
+
+export type ChatAttachmentMetadata = {
+  kind: typeof CHAT_ATTACHMENT_METADATA_KIND
+  name: string
+  size: number
+}
+
+export type ChatAttachmentFileDetails = {
+  isFile: boolean
+  extension: string
+  size: number
+}
+
+export type ChatAttachmentLoadResult =
+  | { status: 'selected'; attachment: ChatAttachment }
+  | { status: 'canceled' }
+  | { status: 'invalid' }
+  | { status: 'failed' }
+
+export type LoadChatAttachment = () => Promise<ChatAttachmentLoadResult>
+
+export type UseChatAttachmentOptions = {
+  /**
+   * 添付ファイルをロードするための関数。
+   * ファイル選択ダイアログを開き、ユーザーが選択したファイルを読み込む処理を実装する。
+   */
+  loadAttachment: LoadChatAttachment
+}
+
+/**
+ * チャット添付ファイルの選択状態とエラー状態を管理する。
+ *
+ * @returns 添付ファイル UI から利用するための API。
+ * - `attachmentFile`: 現在選択されている添付ファイル。未選択時は `null`。
+ * - `attachmentError`: 直近の選択エラー文言。正常時は `null`。
+ * - `selectAttachment`: ファイル選択を実行し、結果に応じて添付状態とエラー状態を更新する。
+ * - `clearAttachment`: 添付ファイルとエラー状態を同時にクリアする。
+ * - `clearAttachmentError`: エラー状態だけをクリアする。
+ * - `createAttachmentMessagePart`: 添付ファイルを送信用のテキストメッセージパートへ変換する。
+ */
+export function useChatAttachment(options: UseChatAttachmentOptions) {
+  const { loadAttachment } = options
+
+  const [attachmentFile, setAttachmentFile] = React.useState<ChatAttachment | null>(null)
+  const [attachmentError, setAttachmentError] = React.useState<string | null>(null)
+
+  const clearAttachmentError = React.useCallback(() => {
+    setAttachmentError(null)
+  }, [])
+
+  const clearAttachment = React.useCallback(() => {
+    setAttachmentFile(null)
+    setAttachmentError(null)
+  }, [])
+
+  const selectAttachment = React.useCallback(async () => {
+    setAttachmentError(null)
+
+    let result: ChatAttachmentLoadResult
+    try {
+      result = await loadAttachment()
+    } catch {
+      setAttachmentError(getAttachmentErrorMessage())
+      return
+    }
+
+    switch (result.status) {
+      case 'selected':
+        setAttachmentFile(result.attachment)
+        return
+      case 'invalid':
+        setAttachmentFile(null)
+        setAttachmentError(getAttachmentErrorMessage())
+        return
+      case 'failed':
+        setAttachmentError(getAttachmentErrorMessage())
+        return
+      case 'canceled':
+        return
+    }
+  }, [loadAttachment])
+
+  return {
+    attachmentFile,
+    attachmentError,
+    selectAttachment,
+    clearAttachment,
+    clearAttachmentError,
+    createAttachmentMessagePart: createChatAttachmentMessagePart,
+  }
+}
+
+export function createChatAttachmentMessagePart(attachment: ChatAttachment) {
+  return {
+    type: 'text' as const,
+    content: toAttachmentPrompt(attachment),
+    metadata: toAttachmentMetadata(attachment),
+  }
+}
+
+export function isChatAttachmentTextPart(
+  part: MessagePart,
+): part is MessagePart & { type: 'text'; metadata: ChatAttachmentMetadata } {
+  if (part.type !== 'text' || !('metadata' in part)) {
+    return false
+  }
+
+  const metadata = (part as { metadata?: unknown }).metadata
+  if (metadata == null || typeof metadata !== 'object') {
+    return false
+  }
+
+  const candidate = metadata as Record<string, unknown>
+  return (
+    candidate.kind === CHAT_ATTACHMENT_METADATA_KIND &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.size === 'number'
+  )
+}
+
+function toAttachmentMetadata(attachment: ChatAttachment): ChatAttachmentMetadata {
+  return {
+    kind: CHAT_ATTACHMENT_METADATA_KIND,
+    name: attachment.name,
+    size: attachment.size,
+  }
+}
+
+function toAttachmentPrompt(attachment: ChatAttachment) {
+  return [
+    '',
+    '',
+    `<attachment name="${attachment.name}" size="${attachment.size}">`,
+    attachment.content,
+    '</attachment>',
+  ].join('\n')
+}
+
+export function getAttachmentErrorMessage() {
+  return `${CHAT_ATTACHMENT_ALLOWED_EXTENSIONS.join('/')} 形式で ${formatBytes(CHAT_ATTACHMENT_MAX_BYTES)} 以下のファイルを選択してください。`
+}
+
+export function isAllowedChatAttachment(file: ChatAttachmentFileDetails) {
+  return (
+    file.isFile &&
+    CHAT_ATTACHMENT_ALLOWED_EXTENSIONS.includes(file.extension.toLowerCase()) &&
+    file.size <= CHAT_ATTACHMENT_MAX_BYTES
+  )
+}

--- a/apps/web/src/features/chat/utils/format-bytes.test.ts
+++ b/apps/web/src/features/chat/utils/format-bytes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatBytes } from './format-bytes'
+
+describe('formatBytes', () => {
+  // -----------------------------------------------------------------------------------------------
+  // バイト数を適切な単位にフォーマットすることを確認する
+  // -----------------------------------------------------------------------------------------------
+  it.each([
+    { size: 512, expected: '512 B' },
+    { size: 1024, expected: '1.0 KB' },
+    { size: 1536, expected: '1.5 KB' },
+    { size: 10 * 1024, expected: '10 KB' },
+    { size: 1024 * 1024, expected: '1.0 MB' },
+  ])('formats $size bytes as $expected', ({ size, expected }) => {
+    expect(formatBytes(size)).toBe(expected)
+  })
+})

--- a/apps/web/src/features/chat/utils/format-bytes.ts
+++ b/apps/web/src/features/chat/utils/format-bytes.ts
@@ -1,0 +1,16 @@
+export function formatBytes(size: number) {
+  if (size < 1024) {
+    return `${size} B`
+  }
+
+  const units = ['KB', 'MB', 'GB']
+  let value = size / 1024
+  let unitIndex = 0
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`
+}

--- a/apps/web/src/features/chat/utils/load-chat-attachment-from-file-system.ts
+++ b/apps/web/src/features/chat/utils/load-chat-attachment-from-file-system.ts
@@ -1,0 +1,47 @@
+import { fs } from '@your-app-name/api/renderer'
+
+import {
+  CHAT_ATTACHMENT_EXTENSIONS,
+  isAllowedChatAttachment,
+} from '@/features/chat/hooks/use-chat-attachment'
+import type { ChatAttachmentLoadResult } from '@/features/chat/hooks/use-chat-attachment'
+
+export async function loadChatAttachmentFromFileSystem(): Promise<ChatAttachmentLoadResult> {
+  const result = await fs.showOpenDialog({
+    title: '添付ファイルを選択',
+    message: '添付ファイルを選択してください',
+    filters: [{ name: 'Text Files', extensions: [...CHAT_ATTACHMENT_EXTENSIONS] }],
+    properties: ['openFile'],
+  })
+
+  if (result.canceled || result.filePaths.length === 0) {
+    return { status: 'canceled' }
+  }
+
+  const filePath = result.filePaths[0]
+  if (!filePath) {
+    return { status: 'canceled' }
+  }
+
+  try {
+    const details = await fs.getFileDetails({ path: filePath })
+
+    if (!isAllowedChatAttachment(details)) {
+      return { status: 'invalid' }
+    }
+
+    const content = await fs.readFileAsText({ path: filePath })
+
+    return {
+      status: 'selected',
+      attachment: {
+        name: details.name,
+        size: details.size,
+        content,
+      },
+    }
+  } catch {
+    console.error(`${new Date().toISOString()} Failed to read attachment file`)
+    return { status: 'failed' }
+  }
+}

--- a/packages/ai-chat/src/chat.ts
+++ b/packages/ai-chat/src/chat.ts
@@ -8,6 +8,14 @@ import type { OllamaModelMessage } from './ollama/ollama'
 import type { ChatRequest, OnChunk, OnDone, OnError } from './types'
 
 const SYSTEM_PROMPT = `このメッセージはSystem Promptとして扱ってください。あなたは自分の知識にないことを推測で答えてはいけません。知らないことはWebSearchツールを使って調べてから回答しなくてはいけません。WebSearchツールが使えない場合にはあなたは知らないと答えなくてはなりません。`
+const DEFAULT_MODEL = 'gpt-oss:20b-cloud'
+
+function getRequestedModel(data: unknown) {
+  if (data != null && typeof data === 'object' && 'model' in data) {
+    return (data as { model?: unknown }).model
+  }
+  return DEFAULT_MODEL
+}
 
 export async function chat(options: {
   request: ChatRequest
@@ -25,10 +33,9 @@ export async function chat(options: {
   } = options
 
   try {
-    console.log(`${new Date().toISOString()} Starting chat with messages:`, messages)
-    console.log(`${new Date().toISOString()} Chat request data:`, data)
+    console.log(`${new Date().toISOString()} Starting chat with ${messages.length} messages`)
 
-    const model = modelSchema.parse((data as any)?.model || 'gpt-oss:20b-cloud')
+    const model = modelSchema.parse(getRequestedModel(data))
     console.log(`${new Date().toISOString()} Using model:`, model)
 
     /** ------------------------------------------------------------------------
@@ -44,16 +51,14 @@ export async function chat(options: {
      *
      * ---------------------------------------------------------------------- */
     const filteredModelMessages: Array<OllamaModelMessage> = []
-    messages.forEach((msg) => {
+    for (const [idx, msg] of messages.entries()) {
       if (isOllamaModelMessage(msg)) {
         filteredModelMessages.push(msg)
       } else {
         // 非対応のメッセージ
-        throw new Error(
-          `${new Date().toISOString()} Skipping unsupported message format: ${JSON.stringify(msg)}`,
-        )
+        throw new Error(`${new Date().toISOString()} Unsupported message format at index ${idx}`)
       }
-    })
+    }
 
     /** ------------------------------------------------------------------------
      *


### PR DESCRIPTION
## 概要

- チャット入力で `.txt` / `.md` ファイルを添付し、本文と一緒に送信できるようにする
- 添付ファイルの選択、サイズ/拡張子検証、エラー表示、送信後クリアを追加する

## 変更内容

- チャット入力欄に添付ファイル選択ボタン、選択中ファイル表示、解除ボタンを追加
- 添付ファイルを送信用の text message part に変換し、モデルへ本文と一緒に渡す処理を追加
- 添付ファイル表示用の metadata 判定を追加し、チャット履歴上では本文ではなくファイル名/サイズを表示
- `.txt` / `.md`、1MB 以下のファイルのみ許可する hook とファイルシステム loader を追加
- byte 表示用の `formatBytes` utility を追加
- `sendMessage` が `MultimodalContent` を受け取れるように型を更新
- AI chat 側の request data から model を安全に取得するようにし、ログ出力を簡略化

## 影響範囲

- `apps/web` のチャット画面、チャット添付ファイル選択 UI、チャット送信処理
- `@your-app-name/api/renderer` 経由の既存 fs API 利用
- `packages/ai-chat` の model 指定取得処理とログ出力

## 動作確認

- [x] `pnpm test` が成功する
- [x] `pnpm dev` で起動できる
- [x] `pnpm build` でビルドして .app を起動できる(macOS)
- [ ] `pnpm build` でビルドして .exe を起動できる(Windows)

## レビュー観点

- 添付ファイルが `.txt` / `.md` かつ 1MB 以下に制限されていること
- 添付あり送信時に、ユーザー入力本文と添付本文が意図通りモデルへ渡ること
- 添付ファイルの選択失敗、無効ファイル、キャンセル時の UI 状態が自然であること
- チャット履歴上で添付本文がそのまま表示されず、ファイル名/サイズ表示になること

## 関連リンク

- なし