### PR TITLE
feat(chat): ツール実行の承認操作を追加

### DIFF
--- a/apps/web/src/features/chat/components/chat-session-provider.tsx
+++ b/apps/web/src/features/chat/components/chat-session-provider.tsx
@@ -20,6 +20,7 @@ type ChatSessionValue = {
   isLoading: boolean
   stop: () => void
   status: ChatClientState
+  addToolApprovalResponse: ReturnType<typeof useChat>['addToolApprovalResponse']
 }
 
 const ChatSessionContext = React.createContext<ChatSessionValue | null>(null)
@@ -81,8 +82,17 @@ export function ChatSessionProvider(props: ChatSessionProviderProps) {
       isLoading: chat.isLoading,
       stop: chat.stop,
       status: chat.status,
+      addToolApprovalResponse: chat.addToolApprovalResponse,
     }
-  }, [chat.isLoading, chat.messages, chat.sendMessage, chat.status, chat.stop, input])
+  }, [
+    chat.isLoading,
+    chat.messages,
+    chat.sendMessage,
+    chat.status,
+    chat.stop,
+    chat.addToolApprovalResponse,
+    input,
+  ])
 
   return <ChatSessionContext.Provider value={value}>{children}</ChatSessionContext.Provider>
 }

--- a/apps/web/src/features/chat/components/chat.tsx
+++ b/apps/web/src/features/chat/components/chat.tsx
@@ -28,8 +28,17 @@ export function Chat() {
   } = useAuth()
   const username = user?.username || 'あなた'
 
-  const { isNotAvailable, input, setInput, messages, sendMessage, isLoading, stop, status } =
-    useChatSession()
+  const {
+    isNotAvailable,
+    input,
+    setInput,
+    messages,
+    sendMessage,
+    isLoading,
+    stop,
+    status,
+    addToolApprovalResponse,
+  } = useChatSession()
 
   const {
     attachmentFile,
@@ -92,7 +101,12 @@ export function Chat() {
                       return <ThinkingContent part={part} />
 
                     case 'tool-call':
-                      return <ToolCallContent part={part} />
+                      return (
+                        <ToolCallContent
+                          part={part}
+                          addToolApprovalResponse={addToolApprovalResponse}
+                        />
+                      )
 
                     case 'tool-result':
                       return <ToolResultContent part={part} />

--- a/apps/web/src/features/chat/components/parts/tool-call-content.tsx
+++ b/apps/web/src/features/chat/components/parts/tool-call-content.tsx
@@ -1,9 +1,17 @@
 import type { ToolCallPart } from '@tanstack/ai-client'
 
+import { Button } from '@repo/ui/components/button'
+
 import { ExpandableSection } from '../utils/expandable-section'
 import { ParameterDisplay } from '../utils/parameter-display'
 
-export function ToolCallContent({ part }: { part: ToolCallPart }) {
+export function ToolCallContent({
+  part,
+  addToolApprovalResponse = () => {},
+}: {
+  part: ToolCallPart
+  addToolApprovalResponse?: (response: { id: string; approved: boolean }) => void
+}) {
   switch (part.state) {
     case 'awaiting-input':
       return (
@@ -25,14 +33,59 @@ export function ToolCallContent({ part }: { part: ToolCallPart }) {
       )
     case 'approval-requested':
       return (
-        <ExpandableSection title={`Tool Call: ${part.name} (Approval Requested)`}>
-          <pre className="font-mono not-italic">{JSON.stringify(part, null, 2)}</pre>
-        </ExpandableSection>
+        <>
+          <ExpandableSection title={`Tool Call: ${part.name} (Approval Requested)`}>
+            {/* <pre className="font-mono not-italic">{JSON.stringify(part, null, 2)}</pre> */}
+            <ParameterDisplay
+              rows={[
+                { label: 'name', value: JSON.stringify(part.name, null, 2) },
+                { label: 'state', value: JSON.stringify(part.state, null, 2) },
+                {
+                  label: 'arguments',
+                  value: formatToolArguments(part.arguments),
+                },
+                { label: 'output', value: JSON.stringify(part.output, null, 2) },
+              ]}
+            />
+          </ExpandableSection>
+          <div className="flex flex-col gap-2 p-2 border rounded-md border-border">
+            <div>
+              <p className="text-sm text-muted-foreground">
+                このツール（{part.name}
+                ）呼び出しは、実行する前に承認が必要です。上記の詳細を確認し、リクエストを承認または拒否することを選択してください。
+              </p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="default"
+                onClick={() => addToolApprovalResponse({ id: part.approval!.id, approved: true })}
+              >
+                承認
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => addToolApprovalResponse({ id: part.approval!.id, approved: false })}
+              >
+                拒否
+              </Button>
+            </div>
+          </div>{' '}
+        </>
       )
     case 'approval-responded':
       return (
         <ExpandableSection title={`Tool Call: ${part.name} (Approval Responded)`}>
-          <pre className="font-mono not-italic">{JSON.stringify(part, null, 2)}</pre>
+          <ParameterDisplay
+            rows={[
+              { label: 'name', value: JSON.stringify(part.name, null, 2) },
+              { label: 'state', value: JSON.stringify(part.state, null, 2) },
+              {
+                label: 'arguments',
+                value: formatToolArguments(part.arguments),
+              },
+              { label: 'output', value: JSON.stringify(part.output, null, 2) },
+            ]}
+          />
         </ExpandableSection>
       )
     case 'complete':

--- a/packages/ai-ollama-tools/src/definition.ts
+++ b/packages/ai-ollama-tools/src/definition.ts
@@ -17,4 +17,5 @@ export const webSearchToolDef = toolDefinition({
       source: z.string(),
     }),
   ),
+  needsApproval: true,
 })


### PR DESCRIPTION
- チャット内のツール呼び出しに対して承認または拒否できる操作を追加
- `useChat` の `addToolApprovalResponse` を chat session 経由で `ToolCallContent` に渡すように変更
- 承認待ちと承認応答済みのツール呼び出し表示を `ParameterDisplay` ベースに整理
- web search tool 定義に `needsApproval` を追加