### PR TITLE
fix: 狭幅時のAIチャットアンマウントを防ぐ

### DIFF
--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -33,7 +33,7 @@ export function Layout(props: { children?: React.ReactNode }) {
 
 function AuthenticatedChatBoundary({ children }: { children: React.ReactNode }) {
   const {
-    auth: { isAuthenticated },
+    auth: { isAuthenticated, user },
   } = useAuth()
 
   if (!isAuthenticated) {
@@ -41,7 +41,7 @@ function AuthenticatedChatBoundary({ children }: { children: React.ReactNode }) 
   }
 
   return (
-    <ChatHost>
+    <ChatHost username={isAuthenticated ? user?.username || 'あなた' : undefined}>
       {children}
     </ChatHost>
   )

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -9,6 +9,9 @@ import {
 import { cn } from '@repo/ui/lib/utils'
 
 import { AppSidebar } from '@/components/app-sidebar'
+import { useAuth } from '@/features/auth/api/auth'
+import { ChatProvider } from '@/features/chat/components/chat'
+import { OpenChatDialog, OpenChatProvider } from '@/features/chat/components/open-chat'
 
 import { Breadcrumbs } from './breadcrumbs'
 
@@ -17,13 +20,34 @@ export function Layout(props: { children?: React.ReactNode }) {
 
   return (
     <SidebarProvider>
-      <div className="w-(--traffic-light-width) group-has-data-[collapsible=icon]/sidebar-wrapper:bg-sidebar h-(--traffic-light-height) group-has-data-[collapsible=icon]/sidebar-wrapper:border-r fixed top-0 left-0 z-99999 pointer-events-none"></div>
-      <AppSidebar variant="sidebar" />
-      <SidebarInset className="h-screen overflow-hidden">
-        <SiteHeader />
-        <div className="w-full h-full overflow-auto">{children}</div>
-      </SidebarInset>
+      <AuthenticatedChatBoundary>
+        <div className="w-(--traffic-light-width) group-has-data-[collapsible=icon]/sidebar-wrapper:bg-sidebar h-(--traffic-light-height) group-has-data-[collapsible=icon]/sidebar-wrapper:border-r fixed top-0 left-0 z-99999 pointer-events-none"></div>
+        <AppSidebar variant="sidebar" />
+        <SidebarInset className="h-screen overflow-hidden">
+          <SiteHeader />
+          <div className="w-full h-full overflow-auto">{children}</div>
+        </SidebarInset>
+      </AuthenticatedChatBoundary>
     </SidebarProvider>
+  )
+}
+
+function AuthenticatedChatBoundary({ children }: { children: React.ReactNode }) {
+  const {
+    auth: { isAuthenticated },
+  } = useAuth()
+
+  if (!isAuthenticated) {
+    return <>{children}</>
+  }
+
+  return (
+    <ChatProvider>
+      <OpenChatProvider>
+        {children}
+        <OpenChatDialog />
+      </OpenChatProvider>
+    </ChatProvider>
   )
 }
 

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -10,8 +10,7 @@ import { cn } from '@repo/ui/lib/utils'
 
 import { AppSidebar } from '@/components/app-sidebar'
 import { useAuth } from '@/features/auth/api/auth'
-import { ChatProvider } from '@/features/chat/components/chat'
-import { OpenChatDialog, OpenChatProvider } from '@/features/chat/components/open-chat'
+import { ChatHost } from '@/features/chat/components/chat-host'
 
 import { Breadcrumbs } from './breadcrumbs'
 
@@ -42,12 +41,9 @@ function AuthenticatedChatBoundary({ children }: { children: React.ReactNode }) 
   }
 
   return (
-    <ChatProvider>
-      <OpenChatProvider>
-        {children}
-        <OpenChatDialog />
-      </OpenChatProvider>
-    </ChatProvider>
+    <ChatHost>
+      {children}
+    </ChatHost>
   )
 }
 

--- a/apps/web/src/features/chat/components/chat-context.tsx
+++ b/apps/web/src/features/chat/components/chat-context.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+
+import type { Model } from '@repo/ai-chat/shared'
+
+type ChatContextValue = {
+  open: boolean
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+  selectedModel: Model
+  setSelectedModel: React.Dispatch<React.SetStateAction<Model>>
+}
+
+const ChatContext = React.createContext<ChatContextValue | null>(null)
+
+export function ChatContextProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode
+  value: ChatContextValue
+}) {
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>
+}
+
+export function useChatDialog() {
+  const { open, setOpen } = useChatContext()
+
+  return {
+    open,
+    setOpen,
+  }
+}
+
+export function useChatModel() {
+  const { selectedModel, setSelectedModel } = useChatContext()
+
+  return {
+    selectedModel,
+    setSelectedModel,
+  }
+}
+
+function useChatContext() {
+  const ctx = React.useContext(ChatContext)
+  if (!ctx) {
+    throw new Error('useChatContext must be used within <ChatHost />')
+  }
+  return ctx
+}

--- a/apps/web/src/features/chat/components/chat-dialog.tsx
+++ b/apps/web/src/features/chat/components/chat-dialog.tsx
@@ -11,10 +11,11 @@ import {
 } from '@repo/ui/components/dialog'
 
 import { Chat } from './chat'
-import { useChatDialog } from './chat-context'
+import { useChatDialog, useChatModel } from './chat-context'
 
 export function ChatDialog() {
   const { open, setOpen } = useChatDialog()
+  const { selectedModel, setSelectedModel } = useChatModel()
 
   return (
     <Dialog modal={false} open={open} onOpenChange={setOpen}>
@@ -41,7 +42,7 @@ export function ChatDialog() {
           </DialogTitle>
           <DialogDescription className="sr-only">AI と会話します。</DialogDescription>
         </DialogHeader>
-        <Chat />
+        <Chat selectedModel={selectedModel} setSelectedModel={setSelectedModel} />
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/features/chat/components/chat-dialog.tsx
+++ b/apps/web/src/features/chat/components/chat-dialog.tsx
@@ -1,0 +1,48 @@
+import { BotIcon, XIcon } from 'lucide-react'
+
+import { Button } from '@repo/ui/components/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@repo/ui/components/dialog'
+
+import { Chat } from './chat'
+import { useChatDialog } from './chat-context'
+
+export function ChatDialog() {
+  const { open, setOpen } = useChatDialog()
+
+  return (
+    <Dialog modal={false} open={open} onOpenChange={setOpen}>
+      <DialogContent
+        showCloseButton={false}
+        className="top-[calc(var(--header-height)+var(--spacing,0.25rem)*2)] left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md border border-primary shadow-lg shadow-primary/30 hover:shadow-primary/50"
+        onInteractOutside={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center justify-between">
+            <div className="flex items-center justify-start text-lg font-semibold gap-1">
+              <BotIcon />
+              <span>AIチャット</span>
+            </div>
+            <div className="flex items-center justify-end gap-1">
+              <DialogClose asChild>
+                <Button variant="ghost" size="sm" className="hover:text-destructive">
+                  <XIcon />
+                </Button>
+              </DialogClose>
+            </div>
+          </DialogTitle>
+          <DialogDescription className="sr-only">AI と会話します。</DialogDescription>
+        </DialogHeader>
+        <Chat />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/features/chat/components/chat-dialog.tsx
+++ b/apps/web/src/features/chat/components/chat-dialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Chat } from './chat'
 import { useChatDialog, useChatModel } from './chat-context'
 
-export function ChatDialog() {
+export function ChatDialog({ username }: { username?: string }) {
   const { open, setOpen } = useChatDialog()
   const { selectedModel, setSelectedModel } = useChatModel()
 
@@ -42,7 +42,11 @@ export function ChatDialog() {
           </DialogTitle>
           <DialogDescription className="sr-only">AI と会話します。</DialogDescription>
         </DialogHeader>
-        <Chat selectedModel={selectedModel} setSelectedModel={setSelectedModel} />
+        <Chat
+          selectedModel={selectedModel}
+          setSelectedModel={setSelectedModel}
+          username={username}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/features/chat/components/chat-host.tsx
+++ b/apps/web/src/features/chat/components/chat-host.tsx
@@ -6,7 +6,7 @@ import { ChatContextProvider } from './chat-context'
 import { ChatDialog } from './chat-dialog'
 import { ChatSessionProvider } from './chat-session-provider'
 
-export function ChatHost({ children }: { children: React.ReactNode }) {
+export function ChatHost({ children, username }: { children: React.ReactNode; username?: string }) {
   const [open, setOpen] = React.useState(false)
   const [selectedModel, setSelectedModel] = React.useState<Model>('gpt-oss:20b-cloud')
 
@@ -24,7 +24,7 @@ export function ChatHost({ children }: { children: React.ReactNode }) {
     <ChatContextProvider value={value}>
       <ChatSessionProvider model={selectedModel}>
         {children}
-        <ChatDialog />
+        <ChatDialog username={username} />
       </ChatSessionProvider>
     </ChatContextProvider>
   )

--- a/apps/web/src/features/chat/components/chat-host.tsx
+++ b/apps/web/src/features/chat/components/chat-host.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+
+import type { Model } from '@repo/ai-chat/shared'
+
+import { ChatContextProvider } from './chat-context'
+import { ChatDialog } from './chat-dialog'
+import { ChatSessionProvider } from './chat-session-provider'
+
+export function ChatHost({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false)
+  const [selectedModel, setSelectedModel] = React.useState<Model>('gpt-oss:20b-cloud')
+
+  const value = React.useMemo(
+    () => ({
+      open,
+      setOpen,
+      selectedModel,
+      setSelectedModel,
+    }),
+    [open, selectedModel],
+  )
+
+  return (
+    <ChatContextProvider value={value}>
+      <ChatSessionProvider model={selectedModel}>
+        {children}
+        <ChatDialog />
+      </ChatSessionProvider>
+    </ChatContextProvider>
+  )
+}

--- a/apps/web/src/features/chat/components/chat.tsx
+++ b/apps/web/src/features/chat/components/chat.tsx
@@ -39,14 +39,43 @@ import { ThinkingContent } from './parts/thinking-content'
 import { ToolCallContent } from './parts/tool-call-content'
 import { ToolResultContent } from './parts/tool-result-content'
 
-export function Chat() {
+type ChatProviderValue = {
+  selectedModel: Model
+  setSelectedModel: React.Dispatch<React.SetStateAction<Model>>
+}
+
+const ChatContext = React.createContext<ChatProviderValue | null>(null)
+
+export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [selectedModel, setSelectedModel] = React.useState<Model>('gpt-oss:20b-cloud')
 
-  return (
-    <ChatSessionProvider model={selectedModel}>
-      <ChatInner selectedModel={selectedModel} setSelectedModel={setSelectedModel} />
-    </ChatSessionProvider>
+  const value = React.useMemo<ChatProviderValue>(
+    () => ({
+      selectedModel,
+      setSelectedModel,
+    }),
+    [selectedModel],
   )
+
+  return (
+    <ChatContext.Provider value={value}>
+      <ChatSessionProvider model={selectedModel}>{children}</ChatSessionProvider>
+    </ChatContext.Provider>
+  )
+}
+
+export function Chat() {
+  const { selectedModel, setSelectedModel } = useChatModel()
+
+  return <ChatInner selectedModel={selectedModel} setSelectedModel={setSelectedModel} />
+}
+
+function useChatModel() {
+  const ctx = React.useContext(ChatContext)
+  if (!ctx) {
+    throw new Error('useChatModel must be used within <ChatProvider />')
+  }
+  return ctx
 }
 
 function ChatInner({

--- a/apps/web/src/features/chat/components/chat.tsx
+++ b/apps/web/src/features/chat/components/chat.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { toast } from 'sonner'
 
 import { MODELS, modelSchema } from '@repo/ai-chat/shared'
@@ -19,7 +17,8 @@ import { useAuth } from '@/features/auth/api/auth'
 
 import { useChatAttachment } from '../hooks/use-chat-attachment'
 import { loadChatAttachmentFromFileSystem } from '../utils/load-chat-attachment-from-file-system'
-import { ChatSessionProvider, useChatSession } from './chat-session-provider'
+import { useChatModel } from './chat-context'
+import { useChatSession } from './chat-session-provider'
 import {
   ComposerAttachmentPreview,
   Composer,
@@ -39,43 +38,10 @@ import { ThinkingContent } from './parts/thinking-content'
 import { ToolCallContent } from './parts/tool-call-content'
 import { ToolResultContent } from './parts/tool-result-content'
 
-type ChatProviderValue = {
-  selectedModel: Model
-  setSelectedModel: React.Dispatch<React.SetStateAction<Model>>
-}
-
-const ChatContext = React.createContext<ChatProviderValue | null>(null)
-
-export function ChatProvider({ children }: { children: React.ReactNode }) {
-  const [selectedModel, setSelectedModel] = React.useState<Model>('gpt-oss:20b-cloud')
-
-  const value = React.useMemo<ChatProviderValue>(
-    () => ({
-      selectedModel,
-      setSelectedModel,
-    }),
-    [selectedModel],
-  )
-
-  return (
-    <ChatContext.Provider value={value}>
-      <ChatSessionProvider model={selectedModel}>{children}</ChatSessionProvider>
-    </ChatContext.Provider>
-  )
-}
-
 export function Chat() {
   const { selectedModel, setSelectedModel } = useChatModel()
 
   return <ChatInner selectedModel={selectedModel} setSelectedModel={setSelectedModel} />
-}
-
-function useChatModel() {
-  const ctx = React.useContext(ChatContext)
-  if (!ctx) {
-    throw new Error('useChatModel must be used within <ChatProvider />')
-  }
-  return ctx
 }
 
 function ChatInner({

--- a/apps/web/src/features/chat/components/chat.tsx
+++ b/apps/web/src/features/chat/components/chat.tsx
@@ -1,15 +1,6 @@
 import { toast } from 'sonner'
 
-import { MODELS, modelSchema } from '@repo/ai-chat/shared'
 import type { Model } from '@repo/ai-chat/shared'
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@repo/ui/components/select'
 import { Separator } from '@repo/ui/components/separator'
 import { aiChat } from '@your-app-name/api/renderer'
 
@@ -17,7 +8,6 @@ import { useAuth } from '@/features/auth/api/auth'
 
 import { useChatAttachment } from '../hooks/use-chat-attachment'
 import { loadChatAttachmentFromFileSystem } from '../utils/load-chat-attachment-from-file-system'
-import { useChatModel } from './chat-context'
 import { useChatSession } from './chat-session-provider'
 import {
   ComposerAttachmentPreview,
@@ -37,14 +27,9 @@ import { TextContent } from './parts/text-content'
 import { ThinkingContent } from './parts/thinking-content'
 import { ToolCallContent } from './parts/tool-call-content'
 import { ToolResultContent } from './parts/tool-result-content'
+import { SelectModel } from './select-model'
 
-export function Chat() {
-  const { selectedModel, setSelectedModel } = useChatModel()
-
-  return <ChatInner selectedModel={selectedModel} setSelectedModel={setSelectedModel} />
-}
-
-function ChatInner({
+export function Chat({
   selectedModel,
   setSelectedModel,
 }: {
@@ -130,23 +115,7 @@ function ChatInner({
   return (
     <div className="flex min-h-0 flex-1 flex-col w-full gap-2">
       <div className="flex shrink-0 justify-end">
-        <Select
-          onValueChange={(value) => setSelectedModel(modelSchema.parse(value))}
-          value={selectedModel}
-        >
-          <SelectTrigger className="max-w-48" size="sm">
-            <SelectValue placeholder="モデル選択" />
-          </SelectTrigger>
-          <SelectContent position="popper">
-            <SelectGroup>
-              {MODELS.map((model) => (
-                <SelectItem key={model} value={model}>
-                  {model}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
+        <SelectModel selectedModel={selectedModel} setSelectedModel={setSelectedModel} />
       </div>
 
       <Messages messages={messages}>

--- a/apps/web/src/features/chat/components/chat.tsx
+++ b/apps/web/src/features/chat/components/chat.tsx
@@ -1,5 +1,17 @@
+import * as React from 'react'
+
 import { toast } from 'sonner'
 
+import { MODELS, modelSchema } from '@repo/ai-chat/shared'
+import type { Model } from '@repo/ai-chat/shared'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@repo/ui/components/select'
 import { Separator } from '@repo/ui/components/separator'
 import { aiChat } from '@your-app-name/api/renderer'
 
@@ -7,7 +19,7 @@ import { useAuth } from '@/features/auth/api/auth'
 
 import { useChatAttachment } from '../hooks/use-chat-attachment'
 import { loadChatAttachmentFromFileSystem } from '../utils/load-chat-attachment-from-file-system'
-import { useChatSession } from './chat-session-provider'
+import { ChatSessionProvider, useChatSession } from './chat-session-provider'
 import {
   ComposerAttachmentPreview,
   Composer,
@@ -28,6 +40,22 @@ import { ToolCallContent } from './parts/tool-call-content'
 import { ToolResultContent } from './parts/tool-result-content'
 
 export function Chat() {
+  const [selectedModel, setSelectedModel] = React.useState<Model>('gpt-oss:20b-cloud')
+
+  return (
+    <ChatSessionProvider model={selectedModel}>
+      <ChatInner selectedModel={selectedModel} setSelectedModel={setSelectedModel} />
+    </ChatSessionProvider>
+  )
+}
+
+function ChatInner({
+  selectedModel,
+  setSelectedModel,
+}: {
+  selectedModel: Model
+  setSelectedModel: (model: Model) => void
+}) {
   const {
     auth: { user },
   } = useAuth()
@@ -105,7 +133,27 @@ export function Chat() {
   const disabledSubmit = (status === 'ready' && !input.trim()) || isNotAvailable
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col w-full gap-4">
+    <div className="flex min-h-0 flex-1 flex-col w-full gap-2">
+      <div className="flex shrink-0 justify-end">
+        <Select
+          onValueChange={(value) => setSelectedModel(modelSchema.parse(value))}
+          value={selectedModel}
+        >
+          <SelectTrigger className="max-w-48" size="sm">
+            <SelectValue placeholder="モデル選択" />
+          </SelectTrigger>
+          <SelectContent position="popper">
+            <SelectGroup>
+              {MODELS.map((model) => (
+                <SelectItem key={model} value={model}>
+                  {model}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+
       <Messages messages={messages}>
         {(message) => (
           <>

--- a/apps/web/src/features/chat/components/chat.tsx
+++ b/apps/web/src/features/chat/components/chat.tsx
@@ -4,8 +4,6 @@ import type { Model } from '@repo/ai-chat/shared'
 import { Separator } from '@repo/ui/components/separator'
 import { aiChat } from '@your-app-name/api/renderer'
 
-import { useAuth } from '@/features/auth/api/auth'
-
 import { useChatAttachment } from '../hooks/use-chat-attachment'
 import { loadChatAttachmentFromFileSystem } from '../utils/load-chat-attachment-from-file-system'
 import { useChatSession } from './chat-session-provider'
@@ -32,14 +30,13 @@ import { SelectModel } from './select-model'
 export function Chat({
   selectedModel,
   setSelectedModel,
+  username,
 }: {
   selectedModel: Model
   setSelectedModel: (model: Model) => void
+  username?: string
 }) {
-  const {
-    auth: { user },
-  } = useAuth()
-  const username = user?.username || 'あなた'
+  const displayUsername = username || 'あなた'
 
   const {
     isNotAvailable,
@@ -121,7 +118,7 @@ export function Chat({
       <Messages messages={messages}>
         {(message) => (
           <>
-            <MessageHeader message={message} username={username} />
+            <MessageHeader message={message} username={displayUsername} />
             <Separator />
             <MessageBody>
               <MessageParts messageParts={message.parts}>

--- a/apps/web/src/features/chat/components/open-chat.tsx
+++ b/apps/web/src/features/chat/components/open-chat.tsx
@@ -1,114 +1,63 @@
-import * as React from 'react'
-
 import { BotIcon, XIcon } from 'lucide-react'
 
-import type { Model } from '@repo/ai-chat/shared'
-import { MODELS, modelSchema } from '@repo/ai-chat/shared'
 import { Button } from '@repo/ui/components/button'
 import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@repo/ui/components/dialog'
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@repo/ui/components/select'
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@repo/ui/components/sidebar'
 
 import { Chat } from './chat'
-import { ChatSessionProvider } from './chat-session-provider'
-
-function isInEmbeddedFrame() {
-  try {
-    return window.self !== window.top
-  } catch {
-    return true
-  }
-}
 
 export function OpenChat() {
-  const [selectedModel, setSelectedModel] = React.useState<Model>('gpt-oss:20b-cloud')
-
-  if (isInEmbeddedFrame()) {
-    return null
-  }
-
-  // AIチャット機能が利用可能かどうかを判定する
-  // const isAiChatAvailable = (window.api as unknown) !== undefined
-
-  // if (!isAiChatAvailable) {
-  //   return null
-  // }
-
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <ChatSessionProvider model={selectedModel}>
-          <Dialog modal={false}>
-            <DialogTrigger asChild>
-              <SidebarMenuButton
-                variant="outline"
-                className="bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-              >
-                <BotIcon />
-                <span>AIチャット</span>
-              </SidebarMenuButton>
-            </DialogTrigger>
-
-            <DialogContent
-              showCloseButton={false}
-              className="top-[calc(var(--header-height)+var(--spacing,0.25rem)*2)] left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md border border-primary shadow-lg shadow-primary/30 hover:shadow-primary/50"
-              // ダイアログ外クリックで閉じないようにする
-              onInteractOutside={(e) => e.preventDefault()}
-              // ダイアログ外クリックで閉じないようにする
-              onPointerDownOutside={(e) => e.preventDefault()}
-              // ESC キーで閉じないようにする
-              onEscapeKeyDown={(e) => e.preventDefault()}
+        <Dialog modal={false}>
+          <DialogTrigger asChild>
+            <SidebarMenuButton
+              variant="outline"
+              className="bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
             >
-              <DialogHeader>
-                <DialogTitle className="flex items-center justify-between">
-                  <div className="flex items-center justify-start text-lg font-semibold gap-1">
-                    <BotIcon />
-                    <span>AIチャット</span>
-                  </div>
-                  <div className="flex items-center justify-end  gap-1">
-                    <Select
-                      onValueChange={(value) => setSelectedModel(modelSchema.parse(value))}
-                      value={selectedModel}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="モデル選択" />
-                      </SelectTrigger>
-                      <SelectContent position="popper">
-                        <SelectGroup>
-                          {MODELS.map((model) => (
-                            <SelectItem key={model} value={model}>
-                              {model}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                    <DialogClose asChild>
-                      <Button variant="ghost" size="sm" className="hover:text-destructive">
-                        <XIcon />
-                      </Button>
-                    </DialogClose>
-                  </div>
-                </DialogTitle>
-              </DialogHeader>
-              <Chat />
-            </DialogContent>
-          </Dialog>
-        </ChatSessionProvider>
+              <BotIcon />
+              <span>AIチャット</span>
+            </SidebarMenuButton>
+          </DialogTrigger>
+
+          <DialogContent
+            showCloseButton={false}
+            className="top-[calc(var(--header-height)+var(--spacing,0.25rem)*2)] left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md border border-primary shadow-lg shadow-primary/30 hover:shadow-primary/50"
+            // ダイアログ外クリックで閉じないようにする
+            onInteractOutside={(e) => e.preventDefault()}
+            // ダイアログ外クリックで閉じないようにする
+            onPointerDownOutside={(e) => e.preventDefault()}
+            // ESC キーで閉じないようにする
+            onEscapeKeyDown={(e) => e.preventDefault()}
+          >
+            <DialogHeader>
+              <DialogTitle className="flex items-center justify-between">
+                <div className="flex items-center justify-start text-lg font-semibold gap-1">
+                  <BotIcon />
+                  <span>AIチャット</span>
+                </div>
+                <div className="flex items-center justify-end  gap-1">
+                  <DialogClose asChild>
+                    <Button variant="ghost" size="sm" className="hover:text-destructive">
+                      <XIcon />
+                    </Button>
+                  </DialogClose>
+                </div>
+              </DialogTitle>
+              <DialogDescription>{/* no-op */}</DialogDescription>
+            </DialogHeader>
+            <Chat />
+          </DialogContent>
+        </Dialog>
       </SidebarMenuItem>
     </SidebarMenu>
   )

--- a/apps/web/src/features/chat/components/open-chat.tsx
+++ b/apps/web/src/features/chat/components/open-chat.tsx
@@ -1,16 +1,5 @@
-import * as React from 'react'
+import { BotIcon } from 'lucide-react'
 
-import { BotIcon, XIcon } from 'lucide-react'
-
-import { Button } from '@repo/ui/components/button'
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@repo/ui/components/dialog'
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -18,31 +7,10 @@ import {
   useSidebar,
 } from '@repo/ui/components/sidebar'
 
-import { Chat } from './chat'
-
-type OpenChatContextValue = {
-  open: boolean
-  setOpen: React.Dispatch<React.SetStateAction<boolean>>
-}
-
-const OpenChatContext = React.createContext<OpenChatContextValue | null>(null)
-
-export function OpenChatProvider({ children }: { children: React.ReactNode }) {
-  const [open, setOpen] = React.useState(false)
-
-  const value = React.useMemo<OpenChatContextValue>(
-    () => ({
-      open,
-      setOpen,
-    }),
-    [open],
-  )
-
-  return <OpenChatContext.Provider value={value}>{children}</OpenChatContext.Provider>
-}
+import { useChatDialog } from './chat-context'
 
 export function OpenChat() {
-  const { open, setOpen } = useOpenChat()
+  const { open, setOpen } = useChatDialog()
   const { isMobile, setOpenMobile } = useSidebar()
 
   const handleOpen = () => {
@@ -68,46 +36,4 @@ export function OpenChat() {
       </SidebarMenuItem>
     </SidebarMenu>
   )
-}
-
-export function OpenChatDialog() {
-  const { open, setOpen } = useOpenChat()
-
-  return (
-    <Dialog modal={false} open={open} onOpenChange={setOpen}>
-      <DialogContent
-        showCloseButton={false}
-        className="top-[calc(var(--header-height)+var(--spacing,0.25rem)*2)] left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md border border-primary shadow-lg shadow-primary/30 hover:shadow-primary/50"
-        onInteractOutside={(e) => e.preventDefault()}
-        onPointerDownOutside={(e) => e.preventDefault()}
-        onEscapeKeyDown={(e) => e.preventDefault()}
-      >
-        <DialogHeader>
-          <DialogTitle className="flex items-center justify-between">
-            <div className="flex items-center justify-start text-lg font-semibold gap-1">
-              <BotIcon />
-              <span>AIチャット</span>
-            </div>
-            <div className="flex items-center justify-end gap-1">
-              <DialogClose asChild>
-                <Button variant="ghost" size="sm" className="hover:text-destructive">
-                  <XIcon />
-                </Button>
-              </DialogClose>
-            </div>
-          </DialogTitle>
-          <DialogDescription className="sr-only">AI と会話します。</DialogDescription>
-        </DialogHeader>
-        <Chat />
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-function useOpenChat() {
-  const ctx = React.useContext(OpenChatContext)
-  if (!ctx) {
-    throw new Error('useOpenChat must be used within <OpenChatProvider />')
-  }
-  return ctx
 }

--- a/apps/web/src/features/chat/components/open-chat.tsx
+++ b/apps/web/src/features/chat/components/open-chat.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react'
+
 import { BotIcon, XIcon } from 'lucide-react'
 
 import { Button } from '@repo/ui/components/button'
@@ -8,57 +10,104 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@repo/ui/components/dialog'
-import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@repo/ui/components/sidebar'
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@repo/ui/components/sidebar'
 
 import { Chat } from './chat'
 
+type OpenChatContextValue = {
+  open: boolean
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const OpenChatContext = React.createContext<OpenChatContextValue | null>(null)
+
+export function OpenChatProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false)
+
+  const value = React.useMemo<OpenChatContextValue>(
+    () => ({
+      open,
+      setOpen,
+    }),
+    [open],
+  )
+
+  return <OpenChatContext.Provider value={value}>{children}</OpenChatContext.Provider>
+}
+
 export function OpenChat() {
+  const { open, setOpen } = useOpenChat()
+  const { isMobile, setOpenMobile } = useSidebar()
+
+  const handleOpen = () => {
+    setOpen(true)
+    if (isMobile) {
+      setOpenMobile(false)
+    }
+  }
+
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <Dialog modal={false}>
-          <DialogTrigger asChild>
-            <SidebarMenuButton
-              variant="outline"
-              className="bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-            >
-              <BotIcon />
-              <span>AIチャット</span>
-            </SidebarMenuButton>
-          </DialogTrigger>
-
-          <DialogContent
-            showCloseButton={false}
-            className="top-[calc(var(--header-height)+var(--spacing,0.25rem)*2)] left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md border border-primary shadow-lg shadow-primary/30 hover:shadow-primary/50"
-            // ダイアログ外クリックで閉じないようにする
-            onInteractOutside={(e) => e.preventDefault()}
-            // ダイアログ外クリックで閉じないようにする
-            onPointerDownOutside={(e) => e.preventDefault()}
-            // ESC キーで閉じないようにする
-            onEscapeKeyDown={(e) => e.preventDefault()}
-          >
-            <DialogHeader>
-              <DialogTitle className="flex items-center justify-between">
-                <div className="flex items-center justify-start text-lg font-semibold gap-1">
-                  <BotIcon />
-                  <span>AIチャット</span>
-                </div>
-                <div className="flex items-center justify-end  gap-1">
-                  <DialogClose asChild>
-                    <Button variant="ghost" size="sm" className="hover:text-destructive">
-                      <XIcon />
-                    </Button>
-                  </DialogClose>
-                </div>
-              </DialogTitle>
-              <DialogDescription>{/* no-op */}</DialogDescription>
-            </DialogHeader>
-            <Chat />
-          </DialogContent>
-        </Dialog>
+        <SidebarMenuButton
+          variant="outline"
+          className="bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+          aria-expanded={open}
+          data-open={open ? true : undefined}
+          onClick={handleOpen}
+        >
+          <BotIcon />
+          <span>AIチャット</span>
+        </SidebarMenuButton>
       </SidebarMenuItem>
     </SidebarMenu>
   )
+}
+
+export function OpenChatDialog() {
+  const { open, setOpen } = useOpenChat()
+
+  return (
+    <Dialog modal={false} open={open} onOpenChange={setOpen}>
+      <DialogContent
+        showCloseButton={false}
+        className="top-[calc(var(--header-height)+var(--spacing,0.25rem)*2)] left-auto right-4 max-h-[calc(100vh-5rem)] translate-x-0 translate-y-0 overflow-hidden flex flex-col sm:max-w-md border border-primary shadow-lg shadow-primary/30 hover:shadow-primary/50"
+        onInteractOutside={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center justify-between">
+            <div className="flex items-center justify-start text-lg font-semibold gap-1">
+              <BotIcon />
+              <span>AIチャット</span>
+            </div>
+            <div className="flex items-center justify-end gap-1">
+              <DialogClose asChild>
+                <Button variant="ghost" size="sm" className="hover:text-destructive">
+                  <XIcon />
+                </Button>
+              </DialogClose>
+            </div>
+          </DialogTitle>
+          <DialogDescription className="sr-only">AI と会話します。</DialogDescription>
+        </DialogHeader>
+        <Chat />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function useOpenChat() {
+  const ctx = React.useContext(OpenChatContext)
+  if (!ctx) {
+    throw new Error('useOpenChat must be used within <OpenChatProvider />')
+  }
+  return ctx
 }

--- a/apps/web/src/features/chat/components/open-chat.tsx
+++ b/apps/web/src/features/chat/components/open-chat.tsx
@@ -10,7 +10,7 @@ import {
 import { useChatDialog } from './chat-context'
 
 export function OpenChat() {
-  const { open, setOpen } = useChatDialog()
+  const { setOpen } = useChatDialog()
   const { isMobile, setOpenMobile } = useSidebar()
 
   const handleOpen = () => {
@@ -26,8 +26,6 @@ export function OpenChat() {
         <SidebarMenuButton
           variant="outline"
           className="bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-          aria-expanded={open}
-          data-open={open ? true : undefined}
           onClick={handleOpen}
         >
           <BotIcon />

--- a/apps/web/src/features/chat/components/select-model.tsx
+++ b/apps/web/src/features/chat/components/select-model.tsx
@@ -1,0 +1,38 @@
+import { MODELS, modelSchema } from '@repo/ai-chat/shared'
+import type { Model } from '@repo/ai-chat/shared'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@repo/ui/components/select'
+
+export function SelectModel({
+  selectedModel,
+  setSelectedModel,
+}: {
+  selectedModel: Model
+  setSelectedModel: (model: Model) => void
+}) {
+  return (
+    <Select
+      onValueChange={(value) => setSelectedModel(modelSchema.parse(value))}
+      value={selectedModel}
+    >
+      <SelectTrigger className="max-w-48" size="sm">
+        <SelectValue placeholder="モデル選択" />
+      </SelectTrigger>
+      <SelectContent position="popper">
+        <SelectGroup>
+          {MODELS.map((model) => (
+            <SelectItem key={model} value={model}>
+              {model}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  )
+}


### PR DESCRIPTION
## 概要

- AIチャットの表示状態・選択モデル・セッション管理を `ChatHost` に集約し、狭幅表示やサイドバー操作時にチャットが不要にアンマウントされないようにします。

## 変更内容

- `Layout` で認証済みユーザー向けに `ChatHost` を配置
- `ChatContext` を追加し、チャットダイアログの open 状態と選択モデルを共有
- `ChatDialog` / `ChatHost` / `SelectModel` を新設し、`OpenChat` から責務を分離
- `OpenChat` をチャット起動ボタンに簡素化し、モバイルでは起動時にサイドバーを閉じるよう変更
- `Chat` が認証情報を直接参照しないようにし、表示ユーザー名とモデル選択を props 経由に整理

## 影響範囲

- `apps/web` のレイアウトおよびAIチャットUI
- 認証済みユーザーのAIチャット起動・表示状態・モデル選択
- モバイル幅でのサイドバーとチャットダイアログの表示挙動

## 動作確認

- [x] `pnpm test` が成功する
- [x] `pnpm dev` で起動できる
- [x] `pnpm build` でビルドして .app を起動できる(macOS)
- [ ] `pnpm build` でビルドして .exe を起動できる(Windows)

## レビュー観点

- 狭幅表示でAIチャットを開いた後、サイドバー開閉によって会話状態が失われないこと
- `ChatHost` が認証済みユーザーにのみ配置されるため、未認証状態で `OpenChat` が描画されない前提で問題ないこと

## 関連リンク

- なし